### PR TITLE
Add media and account models with relationships

### DIFF
--- a/MediaPi.Core/Data/AppDbContext.cs
+++ b/MediaPi.Core/Data/AppDbContext.cs
@@ -36,6 +36,18 @@ namespace MediaPi.Core.Data
         public DbSet<User> Users => Set<User>();
         public DbSet<Role> Roles => Set<Role>();
         public DbSet<UserRole> UserRoles => Set<UserRole>();
+        public DbSet<Video> Videos => Set<Video>();
+        public DbSet<Playlist> Playlists => Set<Playlist>();
+        public DbSet<VideoPlaylist> VideoPlaylists => Set<VideoPlaylist>();
+        public DbSet<Screenshot> Screenshots => Set<Screenshot>();
+        public DbSet<Device> Devices => Set<Device>();
+        public DbSet<DeviceGroup> DeviceGroups => Set<DeviceGroup>();
+        public DbSet<VideoAtDevice> VideoAtDevices => Set<VideoAtDevice>();
+        public DbSet<PlaylistAtDeviceGroup> PlaylistAtDeviceGroups => Set<PlaylistAtDeviceGroup>();
+        public DbSet<Category> Categories => Set<Category>();
+        public DbSet<Account> Accounts => Set<Account>();
+        public DbSet<Subscription> Subscriptions => Set<Subscription>();
+        public DbSet<VideoStatus> VideoStatuses => Set<VideoStatus>();
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
@@ -53,6 +65,67 @@ namespace MediaPi.Core.Data
                 .HasOne(ur => ur.Role)
                 .WithMany(r => r.UserRoles)
                 .HasForeignKey(ur => ur.RoleId);
+
+            modelBuilder.Entity<VideoPlaylist>()
+                .HasKey(vp => new { vp.VideoId, vp.PlaylistId });
+
+            modelBuilder.Entity<VideoPlaylist>()
+                .HasOne(vp => vp.Video)
+                .WithMany(v => v.VideoPlaylists)
+                .HasForeignKey(vp => vp.VideoId);
+
+            modelBuilder.Entity<VideoPlaylist>()
+                .HasOne(vp => vp.Playlist)
+                .WithMany(p => p.VideoPlaylists)
+                .HasForeignKey(vp => vp.PlaylistId);
+
+            modelBuilder.Entity<VideoAtDevice>()
+                .HasKey(vd => new { vd.DeviceId, vd.VideoId });
+
+            modelBuilder.Entity<VideoAtDevice>()
+                .HasOne(vd => vd.Device)
+                .WithMany(d => d.VideoAtDevices)
+                .HasForeignKey(vd => vd.DeviceId);
+
+            modelBuilder.Entity<VideoAtDevice>()
+                .HasOne(vd => vd.Video)
+                .WithMany(v => v.VideoAtDevices)
+                .HasForeignKey(vd => vd.VideoId);
+
+            modelBuilder.Entity<VideoAtDevice>()
+                .HasOne(vd => vd.Status)
+                .WithMany(s => s.VideoAtDevices)
+                .HasForeignKey(vd => vd.StatusId);
+
+            modelBuilder.Entity<PlaylistAtDeviceGroup>()
+                .HasKey(pd => new { pd.DeviceGroupId, pd.PlaylistId });
+
+            modelBuilder.Entity<PlaylistAtDeviceGroup>()
+                .HasOne(pd => pd.DeviceGroup)
+                .WithMany(dg => dg.PlaylistAtDeviceGroups)
+                .HasForeignKey(pd => pd.DeviceGroupId);
+
+            modelBuilder.Entity<PlaylistAtDeviceGroup>()
+                .HasOne(pd => pd.Playlist)
+                .WithMany(p => p.PlaylistAtDeviceGroups)
+                .HasForeignKey(pd => pd.PlaylistId);
+
+            modelBuilder.Entity<PlaylistAtDeviceGroup>()
+                .HasOne(pd => pd.Status)
+                .WithMany(s => s.PlaylistAtDeviceGroups)
+                .HasForeignKey(pd => pd.StatusId);
+
+            modelBuilder.Entity<Device>()
+                .HasOne(d => d.DeviceGroup)
+                .WithMany(g => g.Devices)
+                .HasForeignKey(d => d.DeviceGroupId);
+
+            modelBuilder.Entity<VideoStatus>().HasData(
+                new VideoStatus { Id = StatusConstants.Queued, Name = "Queued" },
+                new VideoStatus { Id = StatusConstants.Loading, Name = "Loading" },
+                new VideoStatus { Id = StatusConstants.Loaded, Name = "Loaded" },
+                new VideoStatus { Id = StatusConstants.Playing, Name = "Playing" }
+            );
 
             modelBuilder.Entity<Role>().HasData(
                 new Role { Id = 1, RoleId = UserRoleConstants.SystemAdministrator, Name = "Администратор системы" },

--- a/MediaPi.Core/Models/Account.cs
+++ b/MediaPi.Core/Models/Account.cs
@@ -1,0 +1,46 @@
+// Copyright (C) 2025 Maxim [maxirmx] Samsonov (www.sw.consulting)
+// All rights reserved.
+// This file is a part of MediaPi Core applicaiton
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+// TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS
+// BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace MediaPi.Core.Models
+{
+    [Table("accounts")]
+    public class Account
+    {
+        [Column("id")]
+        public int Id { get; set; }
+
+        [Column("name")]
+        public required string Name { get; set; }
+
+        public ICollection<Device> Devices { get; set; } = [];
+        public ICollection<DeviceGroup> DeviceGroups { get; set; } = [];
+        public ICollection<Video> Videos { get; set; } = [];
+        public ICollection<Playlist> Playlists { get; set; } = [];
+        public ICollection<Subscription> Subscriptions { get; set; } = [];
+    }
+}
+

--- a/MediaPi.Core/Models/Account.cs
+++ b/MediaPi.Core/Models/Account.cs
@@ -1,6 +1,6 @@
 // Copyright (C) 2025 Maxim [maxirmx] Samsonov (www.sw.consulting)
 // All rights reserved.
-// This file is a part of MediaPi Core applicaiton
+// This file is a part of MediaPi Core application
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/MediaPi.Core/Models/Category.cs
+++ b/MediaPi.Core/Models/Category.cs
@@ -1,0 +1,43 @@
+// Copyright (C) 2025 Maxim [maxirmx] Samsonov (www.sw.consulting)
+// All rights reserved.
+// This file is a part of MediaPi Core applicaiton
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+// TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS
+// BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace MediaPi.Core.Models
+{
+    [Table("categories")]
+    public class Category
+    {
+        [Column("id")]
+        public int Id { get; set; }
+
+        [Column("title")]
+        public required string Title { get; set; }
+
+        public ICollection<Video> Videos { get; set; } = [];
+        public ICollection<Subscription> Subscriptions { get; set; } = [];
+    }
+}
+

--- a/MediaPi.Core/Models/Category.cs
+++ b/MediaPi.Core/Models/Category.cs
@@ -1,6 +1,6 @@
 // Copyright (C) 2025 Maxim [maxirmx] Samsonov (www.sw.consulting)
 // All rights reserved.
-// This file is a part of MediaPi Core applicaiton
+// This file is a part of MediaPi Core application
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/MediaPi.Core/Models/Device.cs
+++ b/MediaPi.Core/Models/Device.cs
@@ -1,6 +1,6 @@
 // Copyright (C) 2025 Maxim [maxirmx] Samsonov (www.sw.consulting)
 // All rights reserved.
-// This file is a part of MediaPi Core applicaiton
+// This file is a part of MediaPi Core application
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/MediaPi.Core/Models/Device.cs
+++ b/MediaPi.Core/Models/Device.cs
@@ -1,0 +1,54 @@
+// Copyright (C) 2025 Maxim [maxirmx] Samsonov (www.sw.consulting)
+// All rights reserved.
+// This file is a part of MediaPi Core applicaiton
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+// TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS
+// BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace MediaPi.Core.Models
+{
+    [Table("devices")]
+    public class Device
+    {
+        [Column("id")]
+        public int Id { get; set; }
+
+        [Column("name")]
+        public required string Name { get; set; }
+
+        [Column("ip_address")]
+        public required string IpAddress { get; set; }
+
+        [Column("account_id")]
+        public int AccountId { get; set; }
+        public Account Account { get; set; } = null!;
+
+        [Column("device_group_id")]
+        public int? DeviceGroupId { get; set; }
+        public DeviceGroup? DeviceGroup { get; set; }
+
+        public ICollection<Screenshot> Screenshots { get; set; } = [];
+        public ICollection<VideoAtDevice> VideoAtDevices { get; set; } = [];
+    }
+}
+

--- a/MediaPi.Core/Models/DeviceGroup.cs
+++ b/MediaPi.Core/Models/DeviceGroup.cs
@@ -1,0 +1,47 @@
+// Copyright (C) 2025 Maxim [maxirmx] Samsonov (www.sw.consulting)
+// All rights reserved.
+// This file is a part of MediaPi Core applicaiton
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+// TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS
+// BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace MediaPi.Core.Models
+{
+    [Table("device_groups")]
+    public class DeviceGroup
+    {
+        [Column("id")]
+        public int Id { get; set; }
+
+        [Column("name")]
+        public required string Name { get; set; }
+
+        [Column("account_id")]
+        public int AccountId { get; set; }
+        public Account Account { get; set; } = null!;
+
+        public ICollection<Device> Devices { get; set; } = [];
+        public ICollection<PlaylistAtDeviceGroup> PlaylistAtDeviceGroups { get; set; } = [];
+    }
+}
+

--- a/MediaPi.Core/Models/DeviceGroup.cs
+++ b/MediaPi.Core/Models/DeviceGroup.cs
@@ -1,6 +1,6 @@
 // Copyright (C) 2025 Maxim [maxirmx] Samsonov (www.sw.consulting)
 // All rights reserved.
-// This file is a part of MediaPi Core applicaiton
+// This file is a part of MediaPi Core application
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/MediaPi.Core/Models/Playlist.cs
+++ b/MediaPi.Core/Models/Playlist.cs
@@ -1,0 +1,50 @@
+// Copyright (C) 2025 Maxim [maxirmx] Samsonov (www.sw.consulting)
+// All rights reserved.
+// This file is a part of MediaPi Core applicaiton
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+// TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS
+// BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace MediaPi.Core.Models
+{
+    [Table("playlists")]
+    public class Playlist
+    {
+        [Column("id")]
+        public int Id { get; set; }
+
+        [Column("title")]
+        public required string Title { get; set; }
+
+        [Column("filename")]
+        public required string Filename { get; set; }
+
+        [Column("account_id")]
+        public int AccountId { get; set; }
+        public Account Account { get; set; } = null!;
+
+        public ICollection<VideoPlaylist> VideoPlaylists { get; set; } = [];
+        public ICollection<PlaylistAtDeviceGroup> PlaylistAtDeviceGroups { get; set; } = [];
+    }
+}
+

--- a/MediaPi.Core/Models/Playlist.cs
+++ b/MediaPi.Core/Models/Playlist.cs
@@ -1,6 +1,6 @@
 // Copyright (C) 2025 Maxim [maxirmx] Samsonov (www.sw.consulting)
 // All rights reserved.
-// This file is a part of MediaPi Core applicaiton
+// This file is a part of MediaPi Core application
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/MediaPi.Core/Models/PlaylistAtDeviceGroup.cs
+++ b/MediaPi.Core/Models/PlaylistAtDeviceGroup.cs
@@ -1,0 +1,46 @@
+// Copyright (C) 2025 Maxim [maxirmx] Samsonov (www.sw.consulting)
+// All rights reserved.
+// This file is a part of MediaPi Core applicaiton
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+// TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS
+// BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace MediaPi.Core.Models
+{
+    [Table("playlist_at_device_groups")]
+    public class PlaylistAtDeviceGroup
+    {
+        [Column("device_group_id")]
+        public int DeviceGroupId { get; set; }
+        public DeviceGroup DeviceGroup { get; set; } = null!;
+
+        [Column("playlist_id")]
+        public int PlaylistId { get; set; }
+        public Playlist Playlist { get; set; } = null!;
+
+        [Column("status_id")]
+        public StatusConstants StatusId { get; set; }
+        public VideoStatus Status { get; set; } = null!;
+    }
+}
+

--- a/MediaPi.Core/Models/PlaylistAtDeviceGroup.cs
+++ b/MediaPi.Core/Models/PlaylistAtDeviceGroup.cs
@@ -1,6 +1,6 @@
 // Copyright (C) 2025 Maxim [maxirmx] Samsonov (www.sw.consulting)
 // All rights reserved.
-// This file is a part of MediaPi Core applicaiton
+// This file is a part of MediaPi Core application
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/MediaPi.Core/Models/Screenshot.cs
+++ b/MediaPi.Core/Models/Screenshot.cs
@@ -1,0 +1,44 @@
+// Copyright (C) 2025 Maxim [maxirmx] Samsonov (www.sw.consulting)
+// All rights reserved.
+// This file is a part of MediaPi Core applicaiton
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+// TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS
+// BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace MediaPi.Core.Models
+{
+    [Table("screenshots")]
+    public class Screenshot
+    {
+        [Column("id")]
+        public int Id { get; set; }
+
+        [Column("timestamp")]
+        public DateTime Timestamp { get; set; }
+
+        [Column("device_id")]
+        public int DeviceId { get; set; }
+        public Device Device { get; set; } = null!;
+    }
+}
+

--- a/MediaPi.Core/Models/Screenshot.cs
+++ b/MediaPi.Core/Models/Screenshot.cs
@@ -1,6 +1,6 @@
 // Copyright (C) 2025 Maxim [maxirmx] Samsonov (www.sw.consulting)
 // All rights reserved.
-// This file is a part of MediaPi Core applicaiton
+// This file is a part of MediaPi Core application
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/MediaPi.Core/Models/StatusConstants.cs
+++ b/MediaPi.Core/Models/StatusConstants.cs
@@ -1,0 +1,36 @@
+// Copyright (C) 2025 Maxim [maxirmx] Samsonov (www.sw.consulting)
+// All rights reserved.
+// This file is a part of MediaPi Core applicaiton
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+// TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS
+// BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+namespace MediaPi.Core.Models
+{
+    public enum StatusConstants
+    {
+        Queued = 1,
+        Loading = 2,
+        Loaded = 3,
+        Playing = 4,
+    }
+}
+

--- a/MediaPi.Core/Models/StatusConstants.cs
+++ b/MediaPi.Core/Models/StatusConstants.cs
@@ -1,6 +1,6 @@
 // Copyright (C) 2025 Maxim [maxirmx] Samsonov (www.sw.consulting)
 // All rights reserved.
-// This file is a part of MediaPi Core applicaiton
+// This file is a part of MediaPi Core application
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/MediaPi.Core/Models/Subscription.cs
+++ b/MediaPi.Core/Models/Subscription.cs
@@ -1,0 +1,54 @@
+// Copyright (C) 2025 Maxim [maxirmx] Samsonov (www.sw.consulting)
+// All rights reserved.
+// This file is a part of MediaPi Core applicaiton
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+// TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS
+// BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace MediaPi.Core.Models
+{
+    [Table("subscriptions")]
+    public class Subscription
+    {
+        [Column("id")]
+        public int Id { get; set; }
+
+        [Column("name")]
+        public required string Name { get; set; }
+
+        [Column("start_time")]
+        public DateTime StartTime { get; set; }
+
+        [Column("end_time")]
+        public DateTime EndTime { get; set; }
+
+        [Column("account_id")]
+        public int AccountId { get; set; }
+        public Account Account { get; set; } = null!;
+
+        [Column("category_id")]
+        public int CategoryId { get; set; }
+        public Category Category { get; set; } = null!;
+    }
+}
+

--- a/MediaPi.Core/Models/Subscription.cs
+++ b/MediaPi.Core/Models/Subscription.cs
@@ -1,6 +1,6 @@
 // Copyright (C) 2025 Maxim [maxirmx] Samsonov (www.sw.consulting)
 // All rights reserved.
-// This file is a part of MediaPi Core applicaiton
+// This file is a part of MediaPi Core application
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/MediaPi.Core/Models/Video.cs
+++ b/MediaPi.Core/Models/Video.cs
@@ -1,0 +1,54 @@
+// Copyright (C) 2025 Maxim [maxirmx] Samsonov (www.sw.consulting)
+// All rights reserved.
+// This file is a part of MediaPi Core applicaiton
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+// TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS
+// BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace MediaPi.Core.Models
+{
+    [Table("videos")]
+    public class Video
+    {
+        [Column("id")]
+        public int Id { get; set; }
+
+        [Column("title")]
+        public required string Title { get; set; }
+
+        [Column("filename")]
+        public required string Filename { get; set; }
+
+        [Column("category_id")]
+        public int? CategoryId { get; set; }
+        public Category? Category { get; set; }
+
+        [Column("account_id")]
+        public int AccountId { get; set; }
+        public Account Account { get; set; } = null!;
+
+        public ICollection<VideoPlaylist> VideoPlaylists { get; set; } = [];
+        public ICollection<VideoAtDevice> VideoAtDevices { get; set; } = [];
+    }
+}
+

--- a/MediaPi.Core/Models/Video.cs
+++ b/MediaPi.Core/Models/Video.cs
@@ -1,6 +1,6 @@
 // Copyright (C) 2025 Maxim [maxirmx] Samsonov (www.sw.consulting)
 // All rights reserved.
-// This file is a part of MediaPi Core applicaiton
+// This file is a part of MediaPi Core application
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/MediaPi.Core/Models/VideoAtDevice.cs
+++ b/MediaPi.Core/Models/VideoAtDevice.cs
@@ -1,0 +1,46 @@
+// Copyright (C) 2025 Maxim [maxirmx] Samsonov (www.sw.consulting)
+// All rights reserved.
+// This file is a part of MediaPi Core applicaiton
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+// TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS
+// BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace MediaPi.Core.Models
+{
+    [Table("video_at_devices")]
+    public class VideoAtDevice
+    {
+        [Column("device_id")]
+        public int DeviceId { get; set; }
+        public Device Device { get; set; } = null!;
+
+        [Column("video_id")]
+        public int VideoId { get; set; }
+        public Video Video { get; set; } = null!;
+
+        [Column("status_id")]
+        public StatusConstants StatusId { get; set; }
+        public VideoStatus Status { get; set; } = null!;
+    }
+}
+

--- a/MediaPi.Core/Models/VideoAtDevice.cs
+++ b/MediaPi.Core/Models/VideoAtDevice.cs
@@ -1,6 +1,6 @@
 // Copyright (C) 2025 Maxim [maxirmx] Samsonov (www.sw.consulting)
 // All rights reserved.
-// This file is a part of MediaPi Core applicaiton
+// This file is a part of MediaPi Core application
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/MediaPi.Core/Models/VideoPlaylist.cs
+++ b/MediaPi.Core/Models/VideoPlaylist.cs
@@ -1,0 +1,42 @@
+// Copyright (C) 2025 Maxim [maxirmx] Samsonov (www.sw.consulting)
+// All rights reserved.
+// This file is a part of MediaPi Core applicaiton
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+// TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS
+// BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace MediaPi.Core.Models
+{
+    [Table("video_playlists")]
+    public class VideoPlaylist
+    {
+        [Column("video_id")]
+        public int VideoId { get; set; }
+        public Video Video { get; set; } = null!;
+
+        [Column("playlist_id")]
+        public int PlaylistId { get; set; }
+        public Playlist Playlist { get; set; } = null!;
+    }
+}
+

--- a/MediaPi.Core/Models/VideoPlaylist.cs
+++ b/MediaPi.Core/Models/VideoPlaylist.cs
@@ -1,6 +1,6 @@
 // Copyright (C) 2025 Maxim [maxirmx] Samsonov (www.sw.consulting)
 // All rights reserved.
-// This file is a part of MediaPi Core applicaiton
+// This file is a part of MediaPi Core application
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/MediaPi.Core/Models/VideoStatus.cs
+++ b/MediaPi.Core/Models/VideoStatus.cs
@@ -1,0 +1,43 @@
+// Copyright (C) 2025 Maxim [maxirmx] Samsonov (www.sw.consulting)
+// All rights reserved.
+// This file is a part of MediaPi Core applicaiton
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+// TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS
+// BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace MediaPi.Core.Models
+{
+    [Table("video_statuses")]
+    public class VideoStatus
+    {
+        [Column("id")]
+        public StatusConstants Id { get; set; }
+
+        [Column("name")]
+        public required string Name { get; set; }
+
+        public ICollection<VideoAtDevice> VideoAtDevices { get; set; } = [];
+        public ICollection<PlaylistAtDeviceGroup> PlaylistAtDeviceGroups { get; set; } = [];
+    }
+}
+

--- a/MediaPi.Core/Models/VideoStatus.cs
+++ b/MediaPi.Core/Models/VideoStatus.cs
@@ -1,6 +1,6 @@
 // Copyright (C) 2025 Maxim [maxirmx] Samsonov (www.sw.consulting)
 // All rights reserved.
-// This file is a part of MediaPi Core applicaiton
+// This file is a part of MediaPi Core application
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions


### PR DESCRIPTION
## Summary
- introduce status enumeration and persistent `VideoStatus`
- add domain models for videos, playlists, devices, device groups, categories, accounts and subscriptions
- configure EF Core context with join tables and seeded statuses

## Testing
- `dotnet test MediaPi.sln`


------
https://chatgpt.com/codex/tasks/task_e_688dc0f497f88321b3a20594e491fdbc