### PR TITLE
Add device controller with registration and group assignments

### DIFF
--- a/MediaPi.Core.Tests/Controllers/DevicesControllerTests.cs
+++ b/MediaPi.Core.Tests/Controllers/DevicesControllerTests.cs
@@ -1,0 +1,420 @@
+// MIT License
+//
+// Copyright (c) 2025 Maxim [maxirmx] Samsonov (www.sw.consulting)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+
+using Moq;
+using NUnit.Framework;
+
+using System.Linq;
+using System.Net;
+using System.Threading.Tasks;
+
+using MediaPi.Core.Controllers;
+using MediaPi.Core.Data;
+using MediaPi.Core.Models;
+using MediaPi.Core.RestModels;
+
+namespace MediaPi.Core.Tests.Controllers;
+
+[TestFixture]
+public class DevicesControllerTests
+{
+#pragma warning disable CS8618
+    private Mock<IHttpContextAccessor> _mockHttpContextAccessor;
+    private Mock<ILogger<DevicesController>> _mockLogger;
+    private AppDbContext _dbContext;
+    private DevicesController _controller;
+    private User _admin;
+    private User _manager;
+    private User _engineer;
+    private Role _adminRole;
+    private Role _managerRole;
+    private Role _engineerRole;
+    private Account _account1;
+    private Account _account2;
+#pragma warning restore CS8618
+
+    [SetUp]
+    public void Setup()
+    {
+        var options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase($"device_controller_test_db_{System.Guid.NewGuid()}")
+            .Options;
+
+        _dbContext = new AppDbContext(options);
+
+        _adminRole = new Role { RoleId = UserRoleConstants.SystemAdministrator, Name = "Admin" };
+        _managerRole = new Role { RoleId = UserRoleConstants.AccountManager, Name = "Manager" };
+        _engineerRole = new Role { RoleId = UserRoleConstants.InstallationEngineer, Name = "Engineer" };
+        _dbContext.Roles.AddRange(_adminRole, _managerRole, _engineerRole);
+
+        _account1 = new Account { Id = 1, Name = "Acc1" };
+        _account2 = new Account { Id = 2, Name = "Acc2" };
+        _dbContext.Accounts.AddRange(_account1, _account2);
+
+        string pass = BCrypt.Net.BCrypt.HashPassword("pwd");
+
+        _admin = new User
+        {
+            Id = 1,
+            Email = "admin@example.com",
+            Password = pass,
+            UserRoles = [ new UserRole { UserId = 1, RoleId = _adminRole.Id, Role = _adminRole } ]
+        };
+
+        _manager = new User
+        {
+            Id = 2,
+            Email = "manager@example.com",
+            Password = pass,
+            UserRoles = [ new UserRole { UserId = 2, RoleId = _managerRole.Id, Role = _managerRole } ],
+            UserAccounts = [ new UserAccount { UserId = 2, AccountId = _account1.Id, Account = _account1 } ]
+        };
+
+        _engineer = new User
+        {
+            Id = 3,
+            Email = "eng@example.com",
+            Password = pass,
+            UserRoles = [ new UserRole { UserId = 3, RoleId = _engineerRole.Id, Role = _engineerRole } ]
+        };
+
+        var d1 = new Device { Id = 1, Name = "Dev1", IpAddress = "1.1.1.1", AccountId = _account1.Id };
+        var d2 = new Device { Id = 2, Name = "Dev2", IpAddress = "2.2.2.2" };
+        var d3 = new Device { Id = 3, Name = "Dev3", IpAddress = "3.3.3.3", AccountId = _account2.Id };
+
+        _dbContext.Users.AddRange(_admin, _manager, _engineer);
+        _dbContext.Devices.AddRange(d1, d2, d3);
+        _dbContext.SaveChanges();
+
+        _mockHttpContextAccessor = new Mock<IHttpContextAccessor>();
+        _mockLogger = new Mock<ILogger<DevicesController>>();
+    }
+
+    private void SetCurrentUser(int? id, string? ip = null)
+    {
+        var context = new DefaultHttpContext();
+        if (id.HasValue) context.Items["UserId"] = id.Value;
+        if (ip != null) context.Connection.RemoteIpAddress = IPAddress.Parse(ip);
+        _mockHttpContextAccessor.Setup(x => x.HttpContext).Returns(context);
+        _controller = new DevicesController(_mockHttpContextAccessor.Object, _dbContext, _mockLogger.Object)
+        {
+            ControllerContext = new ControllerContext { HttpContext = context }
+        };
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        _dbContext.Database.EnsureDeleted();
+        _dbContext.Dispose();
+    }
+
+    [Test]
+    public async Task Register_CreatesDeviceWithRemoteIp()
+    {
+        SetCurrentUser(null, "5.6.7.8");
+        var result = await _controller.Register();
+        var created = result.Result as CreatedAtActionResult;
+        Assert.That(created, Is.Not.Null);
+        var reference = created!.Value as Reference;
+        Assert.That(reference, Is.Not.Null);
+        var dev = await _dbContext.Devices.FindAsync(reference!.Id);
+        Assert.That(dev, Is.Not.Null);
+        Assert.That(dev!.IpAddress, Is.EqualTo("5.6.7.8"));
+        Assert.That(dev.Name, Is.EqualTo($"Устройство №{dev.Id}"));
+        Assert.That(dev.AccountId, Is.Null);
+        Assert.That(dev.DeviceGroupId, Is.Null);
+    }
+
+    [Test]
+    public async Task GetAll_Admin_ReturnsAll()
+    {
+        SetCurrentUser(1);
+        var result = await _controller.GetAll();
+        Assert.That(result.Value, Is.Not.Null);
+        Assert.That(result.Value!.Count(), Is.EqualTo(3));
+    }
+
+    [Test]
+    public async Task GetAll_Manager_FiltersByAccount()
+    {
+        SetCurrentUser(2);
+        var result = await _controller.GetAll();
+        Assert.That(result.Value, Is.Not.Null);
+        var list = result.Value!.ToList();
+        Assert.That(list, Has.Count.EqualTo(1));
+        Assert.That(list[0].Id, Is.EqualTo(1));
+    }
+
+    [Test]
+    public async Task GetAll_Engineer_ReturnsUnassigned()
+    {
+        SetCurrentUser(3);
+        var result = await _controller.GetAll();
+        Assert.That(result.Value, Is.Not.Null);
+        var list = result.Value!.ToList();
+        Assert.That(list, Has.Count.EqualTo(1));
+        Assert.That(list[0].Id, Is.EqualTo(2));
+    }
+
+    [Test]
+    public async Task Get_Admin_CanRetrieveAny()
+    {
+        SetCurrentUser(1);
+        var result = await _controller.GetDevice(3);
+        Assert.That(result.Value, Is.Not.Null);
+        Assert.That(result.Value!.Id, Is.EqualTo(3));
+    }
+
+    [Test]
+    public async Task Get_Manager_OwnDevice_Succeeds()
+    {
+        SetCurrentUser(2);
+        var result = await _controller.GetDevice(1);
+        Assert.That(result.Value, Is.Not.Null);
+    }
+
+    [Test]
+    public async Task Get_Manager_OtherDevice_Forbidden()
+    {
+        SetCurrentUser(2);
+        var result = await _controller.GetDevice(3);
+        Assert.That(result.Result, Is.TypeOf<ObjectResult>());
+        var obj = result.Result as ObjectResult;
+        Assert.That(obj!.StatusCode, Is.EqualTo(StatusCodes.Status403Forbidden));
+    }
+
+    [Test]
+    public async Task Get_Engineer_Unassigned_Succeeds()
+    {
+        SetCurrentUser(3);
+        var result = await _controller.GetDevice(2);
+        Assert.That(result.Value, Is.Not.Null);
+    }
+
+    [Test]
+    public async Task Get_Engineer_Assigned_Forbidden()
+    {
+        SetCurrentUser(3);
+        var result = await _controller.GetDevice(1);
+        Assert.That(result.Result, Is.TypeOf<ObjectResult>());
+        var obj = result.Result as ObjectResult;
+        Assert.That(obj!.StatusCode, Is.EqualTo(StatusCodes.Status403Forbidden));
+    }
+
+    [Test]
+    public async Task Update_Admin_ValidIp_Succeeds()
+    {
+        SetCurrentUser(1);
+        var dto = new DeviceUpdateItem { IpAddress = "10.0.0.1" };
+        var response = await _controller.UpdateDevice(1, dto);
+        Assert.That(response, Is.TypeOf<NoContentResult>());
+        var dev = await _dbContext.Devices.FindAsync(1);
+        Assert.That(dev!.IpAddress, Is.EqualTo("10.0.0.1"));
+    }
+
+    [Test]
+    public async Task Update_Admin_InvalidIp_ReturnsBadRequest()
+    {
+        SetCurrentUser(1);
+        var dto = new DeviceUpdateItem { IpAddress = "bad-ip" };
+        var response = await _controller.UpdateDevice(1, dto);
+        Assert.That(response, Is.TypeOf<ObjectResult>());
+        var obj = response as ObjectResult;
+        Assert.That(obj!.StatusCode, Is.EqualTo(StatusCodes.Status400BadRequest));
+    }
+
+    [Test]
+    public async Task Update_NotAdmin_ReturnsForbidden()
+    {
+        SetCurrentUser(2);
+        var dto = new DeviceUpdateItem { IpAddress = "10.0.0.1" };
+        var response = await _controller.UpdateDevice(1, dto);
+        Assert.That(response, Is.TypeOf<ObjectResult>());
+        var obj = response as ObjectResult;
+        Assert.That(obj!.StatusCode, Is.EqualTo(StatusCodes.Status403Forbidden));
+    }
+
+    [Test]
+    public async Task AssignGroup_Admin_Succeeds()
+    {
+        SetCurrentUser(1);
+        var dto = new DeviceAssignGroupItem { DeviceGroupId = 5 };
+        var response = await _controller.AssignGroup(1, dto);
+        Assert.That(response, Is.TypeOf<NoContentResult>());
+        var dev = await _dbContext.Devices.FindAsync(1);
+        Assert.That(dev!.DeviceGroupId, Is.EqualTo(5));
+    }
+
+    [Test]
+    public async Task AssignGroup_Manager_OwnDevice_Succeeds()
+    {
+        SetCurrentUser(2);
+        var dto = new DeviceAssignGroupItem { DeviceGroupId = 7 };
+        var response = await _controller.AssignGroup(1, dto);
+        Assert.That(response, Is.TypeOf<NoContentResult>());
+        var dev = await _dbContext.Devices.FindAsync(1);
+        Assert.That(dev!.DeviceGroupId, Is.EqualTo(7));
+    }
+
+    [Test]
+    public async Task AssignGroup_Manager_OtherDevice_Forbidden()
+    {
+        SetCurrentUser(2);
+        var dto = new DeviceAssignGroupItem { DeviceGroupId = 7 };
+        var response = await _controller.AssignGroup(3, dto);
+        Assert.That(response, Is.TypeOf<ObjectResult>());
+        var obj = response as ObjectResult;
+        Assert.That(obj!.StatusCode, Is.EqualTo(StatusCodes.Status403Forbidden));
+    }
+
+    [Test]
+    public async Task AssignGroup_Engineer_Forbidden()
+    {
+        SetCurrentUser(3);
+        var dto = new DeviceAssignGroupItem { DeviceGroupId = 7 };
+        var response = await _controller.AssignGroup(2, dto);
+        Assert.That(response, Is.TypeOf<ObjectResult>());
+        var obj = response as ObjectResult;
+        Assert.That(obj!.StatusCode, Is.EqualTo(StatusCodes.Status403Forbidden));
+    }
+
+    [Test]
+    public async Task InitialAssignAccount_Admin_Succeeds()
+    {
+        SetCurrentUser(1);
+        var dto = new DeviceInitialAssignAccountItem { Name = "NewName", AccountId = _account1.Id };
+        var response = await _controller.InitialAssignAccount(2, dto);
+        Assert.That(response, Is.TypeOf<NoContentResult>());
+        var dev = await _dbContext.Devices.FindAsync(2);
+        Assert.That(dev!.AccountId, Is.EqualTo(_account1.Id));
+        Assert.That(dev.Name, Is.EqualTo("NewName"));
+    }
+
+    [Test]
+    public async Task InitialAssignAccount_Engineer_Unassigned_Succeeds()
+    {
+        SetCurrentUser(3);
+        var dto = new DeviceInitialAssignAccountItem { Name = "Init", AccountId = _account1.Id };
+        var response = await _controller.InitialAssignAccount(2, dto);
+        Assert.That(response, Is.TypeOf<NoContentResult>());
+    }
+
+    [Test]
+    public async Task InitialAssignAccount_Engineer_Assigned_Forbidden()
+    {
+        SetCurrentUser(3);
+        var dto = new DeviceInitialAssignAccountItem { Name = "Init", AccountId = _account1.Id };
+        var response = await _controller.InitialAssignAccount(1, dto);
+        Assert.That(response, Is.TypeOf<ObjectResult>());
+        var obj = response as ObjectResult;
+        Assert.That(obj!.StatusCode, Is.EqualTo(StatusCodes.Status403Forbidden));
+    }
+
+    [Test]
+    public async Task InitialAssignAccount_Manager_Forbidden()
+    {
+        SetCurrentUser(2);
+        var dto = new DeviceInitialAssignAccountItem { Name = "Init", AccountId = _account1.Id };
+        var response = await _controller.InitialAssignAccount(2, dto);
+        Assert.That(response, Is.TypeOf<ObjectResult>());
+        var obj = response as ObjectResult;
+        Assert.That(obj!.StatusCode, Is.EqualTo(StatusCodes.Status403Forbidden));
+    }
+
+    [Test]
+    public async Task Delete_Admin_Succeeds()
+    {
+        SetCurrentUser(1);
+        var response = await _controller.DeleteDevice(1);
+        Assert.That(response, Is.TypeOf<NoContentResult>());
+        Assert.That(await _dbContext.Devices.FindAsync(1), Is.Null);
+    }
+
+    [Test]
+    public async Task Delete_NotAdmin_Forbidden()
+    {
+        SetCurrentUser(2);
+        var response = await _controller.DeleteDevice(1);
+        Assert.That(response, Is.TypeOf<ObjectResult>());
+        var obj = response as ObjectResult;
+        Assert.That(obj!.StatusCode, Is.EqualTo(StatusCodes.Status403Forbidden));
+    }
+
+    [Test]
+    public async Task Get_NotFound_Returns404()
+    {
+        SetCurrentUser(1);
+        var result = await _controller.GetDevice(999);
+        Assert.That(result.Result, Is.TypeOf<ObjectResult>());
+        var obj = result.Result as ObjectResult;
+        Assert.That(obj!.StatusCode, Is.EqualTo(StatusCodes.Status404NotFound));
+    }
+
+    [Test]
+    public async Task Update_NotFound_Returns404()
+    {
+        SetCurrentUser(1);
+        var response = await _controller.UpdateDevice(999, new DeviceUpdateItem());
+        Assert.That(response, Is.TypeOf<ObjectResult>());
+        var obj = response as ObjectResult;
+        Assert.That(obj!.StatusCode, Is.EqualTo(StatusCodes.Status404NotFound));
+    }
+
+    [Test]
+    public async Task Delete_NotFound_Returns404()
+    {
+        SetCurrentUser(1);
+        var response = await _controller.DeleteDevice(999);
+        Assert.That(response, Is.TypeOf<ObjectResult>());
+        var obj = response as ObjectResult;
+        Assert.That(obj!.StatusCode, Is.EqualTo(StatusCodes.Status404NotFound));
+    }
+
+    [Test]
+    public async Task AssignGroup_NotFound_Returns404()
+    {
+        SetCurrentUser(1);
+        var dto = new DeviceAssignGroupItem { DeviceGroupId = 1 };
+        var response = await _controller.AssignGroup(999, dto);
+        Assert.That(response, Is.TypeOf<ObjectResult>());
+        var obj = response as ObjectResult;
+        Assert.That(obj!.StatusCode, Is.EqualTo(StatusCodes.Status404NotFound));
+    }
+
+    [Test]
+    public async Task InitialAssignAccount_NotFound_Returns404()
+    {
+        SetCurrentUser(1);
+        var dto = new DeviceInitialAssignAccountItem { Name = "N", AccountId = _account1.Id };
+        var response = await _controller.InitialAssignAccount(999, dto);
+        Assert.That(response, Is.TypeOf<ObjectResult>());
+        var obj = response as ObjectResult;
+        Assert.That(obj!.StatusCode, Is.EqualTo(StatusCodes.Status404NotFound));
+    }
+}
+

--- a/MediaPi.Core.Tests/Controllers/StatusControllerTests.cs
+++ b/MediaPi.Core.Tests/Controllers/StatusControllerTests.cs
@@ -73,7 +73,7 @@ public class StatusControllerTests
         var status = okResult!.Value as Status;
         Assert.That(status, Is.Not.Null);
 
-        Assert.That(status!.Msg, Does.Contain("Fuelflux Core"));
+        Assert.That(status!.Msg, Does.Contain("MediaPi Core"));
         Assert.That(status.AppVersion, Is.EqualTo(VersionInfo.AppVersion));
         Assert.That(status.DbVersion, Is.Not.Null.And.Not.Empty);
     }

--- a/MediaPi.Core/Controllers/DevicesController.cs
+++ b/MediaPi.Core/Controllers/DevicesController.cs
@@ -1,0 +1,225 @@
+// MIT License
+//
+// Copyright (c) 2025 Maxim [maxirmx] Samsonov (www.sw.consulting)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+
+using System.Net;
+using System.Linq;
+
+using MediaPi.Core.Authorization;
+using MediaPi.Core.Data;
+using MediaPi.Core.Models;
+using MediaPi.Core.RestModels;
+using MediaPi.Core.Extensions;
+
+namespace MediaPi.Core.Controllers;
+
+[ApiController]
+[Authorize]
+[Route("api/[controller]")]
+[Produces("application/json")]
+[ProducesResponseType(StatusCodes.Status401Unauthorized, Type = typeof(ErrMessage))]
+public class DevicesController(
+    IHttpContextAccessor httpContextAccessor,
+    AppDbContext db,
+    ILogger<DevicesController> logger) : MediaPiControllerBase(httpContextAccessor, db, logger)
+{
+    private async Task<User?> CurrentUser()
+    {
+        return await _db.Users
+            .Include(u => u.UserRoles).ThenInclude(ur => ur.Role)
+            .Include(u => u.UserAccounts)
+            .FirstOrDefaultAsync(u => u.Id == _curUserId);
+    }
+
+    private bool ManagerOwnsDevice(User user, Device device)
+    {
+        var accountIds = user.UserAccounts.Select(ua => ua.AccountId);
+        return device.AccountId != null && accountIds.Contains(device.AccountId.Value);
+    }
+
+    // POST: api/devices/register
+    [AllowAnonymous]
+    [HttpPost("register")]
+    [ProducesResponseType(StatusCodes.Status201Created, Type = typeof(Reference))]
+    public async Task<ActionResult<Reference>> Register()
+    {
+        var ip = HttpContext.Connection.RemoteIpAddress?.ToString() ?? "";
+        var device = new Device { Name = string.Empty, IpAddress = ip };
+        _db.Devices.Add(device);
+        await _db.SaveChangesAsync();
+        device.Name = $"Устройство №{device.Id}";
+        await _db.SaveChangesAsync();
+        return CreatedAtAction(nameof(GetDevice), new { id = device.Id }, new Reference { Id = device.Id });
+    }
+
+    // GET: api/devices
+    [HttpGet]
+    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(IEnumerable<DeviceViewItem>))]
+    [ProducesResponseType(StatusCodes.Status403Forbidden, Type = typeof(ErrMessage))]
+    public async Task<ActionResult<IEnumerable<DeviceViewItem>>> GetAll()
+    {
+        var user = await CurrentUser();
+        if (user == null) return _403();
+
+        IQueryable<Device> query = _db.Devices;
+        if (user.IsAdministrator())
+        {
+            // all devices
+        }
+        else if (user.IsManager())
+        {
+            var accountIds = user.UserAccounts.Select(ua => ua.AccountId).ToList();
+            query = query.Where(d => d.AccountId != null && accountIds.Contains(d.AccountId.Value));
+        }
+        else if (user.HasRole(UserRoleConstants.InstallationEngineer))
+        {
+            query = query.Where(d => d.AccountId == null);
+        }
+        else
+        {
+            return _403();
+        }
+
+        var devices = await query.ToListAsync();
+        return devices.Select(d => d.ToViewItem()).ToList();
+    }
+
+    // GET: api/devices/5
+    [HttpGet("{id}")]
+    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(DeviceViewItem))]
+    [ProducesResponseType(StatusCodes.Status403Forbidden, Type = typeof(ErrMessage))]
+    [ProducesResponseType(StatusCodes.Status404NotFound, Type = typeof(ErrMessage))]
+    public async Task<ActionResult<DeviceViewItem>> GetDevice(int id)
+    {
+        var user = await CurrentUser();
+        if (user == null) return _403();
+
+        var device = await _db.Devices.FindAsync(id);
+        if (device == null) return _404Device(id);
+
+        if (user.IsAdministrator() ||
+            (user.IsManager() && ManagerOwnsDevice(user, device)) ||
+            (user.HasRole(UserRoleConstants.InstallationEngineer) && device.AccountId == null))
+        {
+            return device.ToViewItem();
+        }
+
+        return _403();
+    }
+
+    // PUT: api/devices/5
+    [HttpPut("{id}")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest, Type = typeof(ErrMessage))]
+    [ProducesResponseType(StatusCodes.Status403Forbidden, Type = typeof(ErrMessage))]
+    [ProducesResponseType(StatusCodes.Status404NotFound, Type = typeof(ErrMessage))]
+    public async Task<IActionResult> UpdateDevice(int id, DeviceUpdateItem item)
+    {
+        var user = await CurrentUser();
+        if (user == null || !user.IsAdministrator()) return _403();
+
+        if (item.IpAddress != null && !IPAddress.TryParse(item.IpAddress, out _))
+        {
+            return _400Ip(item.IpAddress);
+        }
+
+        var device = await _db.Devices.FindAsync(id);
+        if (device == null) return _404Device(id);
+
+        device.UpdateFrom(item);
+        _db.Entry(device).State = EntityState.Modified;
+        await _db.SaveChangesAsync();
+
+        return NoContent();
+    }
+
+    // DELETE: api/devices/5
+    [HttpDelete("{id}")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden, Type = typeof(ErrMessage))]
+    [ProducesResponseType(StatusCodes.Status404NotFound, Type = typeof(ErrMessage))]
+    public async Task<IActionResult> DeleteDevice(int id)
+    {
+        var user = await CurrentUser();
+        if (user == null || !user.IsAdministrator()) return _403();
+
+        var device = await _db.Devices.FindAsync(id);
+        if (device == null) return _404Device(id);
+
+        _db.Devices.Remove(device);
+        await _db.SaveChangesAsync();
+
+        return NoContent();
+    }
+
+    // PATCH: api/devices/{id}/assign-group
+    [HttpPatch("{id}/assign-group")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden, Type = typeof(ErrMessage))]
+    [ProducesResponseType(StatusCodes.Status404NotFound, Type = typeof(ErrMessage))]
+    public async Task<IActionResult> AssignGroup(int id, DeviceAssignGroupItem item)
+    {
+        var user = await CurrentUser();
+        if (user == null) return _403();
+
+        var device = await _db.Devices.FindAsync(id);
+        if (device == null) return _404Device(id);
+
+        if (user.IsAdministrator() || (user.IsManager() && ManagerOwnsDevice(user, device)))
+        {
+            device.AssignGroupFrom(item);
+            _db.Entry(device).State = EntityState.Modified;
+            await _db.SaveChangesAsync();
+            return NoContent();
+        }
+
+        return _403();
+    }
+
+    // PATCH: api/devices/{id}/initial-assign-account
+    [HttpPatch("{id}/initial-assign-account")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden, Type = typeof(ErrMessage))]
+    [ProducesResponseType(StatusCodes.Status404NotFound, Type = typeof(ErrMessage))]
+    public async Task<IActionResult> InitialAssignAccount(int id, DeviceInitialAssignAccountItem item)
+    {
+        var user = await CurrentUser();
+        if (user == null) return _403();
+
+        var device = await _db.Devices.FindAsync(id);
+        if (device == null) return _404Device(id);
+
+        if (user.IsAdministrator() ||
+            (user.HasRole(UserRoleConstants.InstallationEngineer) && device.AccountId == null))
+        {
+            device.InitialAssignAccountFrom(item);
+            _db.Entry(device).State = EntityState.Modified;
+            await _db.SaveChangesAsync();
+            return NoContent();
+        }
+
+        return _403();
+    }
+}
+

--- a/MediaPi.Core/Controllers/MediaPiControllerBase.cs
+++ b/MediaPi.Core/Controllers/MediaPiControllerBase.cs
@@ -71,10 +71,21 @@ public class FuelfluxControllerPreBase(AppDbContext db, ILogger logger) : Contro
         return StatusCode(StatusCodes.Status404NotFound,
                           new ErrMessage { Msg = $"Не удалось найти реестр [id={id}]" });
     }
+    protected ObjectResult _404Device(int id)
+    {
+        return StatusCode(StatusCodes.Status404NotFound,
+                          new ErrMessage { Msg = $"Не удалось найти устройство [id={id}]" });
+    }
     protected ObjectResult _409Email(string email)
     {
         return StatusCode(StatusCodes.Status409Conflict,
                           new ErrMessage { Msg = $"Пользователь с таким адресом электронной почты уже зарегистрирован [email = {email}]" });
+    }
+
+    protected ObjectResult _400Ip(string ip)
+    {
+        return StatusCode(StatusCodes.Status400BadRequest,
+                          new ErrMessage { Msg = $"Неверный формат IP адреса [{ip}]" });
     }
     protected ObjectResult _500Mapping(string fname)
     {

--- a/MediaPi.Core/Extensions/DeviceExtensions.cs
+++ b/MediaPi.Core/Extensions/DeviceExtensions.cs
@@ -20,32 +20,32 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-using System.ComponentModel.DataAnnotations.Schema;
+using MediaPi.Core.Models;
+using MediaPi.Core.RestModels;
 
-namespace MediaPi.Core.Models
+namespace MediaPi.Core.Extensions;
+
+public static class DeviceExtensions
 {
-    [Table("devices")]
-    public class Device
+    public static DeviceViewItem ToViewItem(this Device device) => new(device);
+
+    public static void UpdateFrom(this Device device, DeviceUpdateItem item)
     {
-        [Column("id")]
-        public int Id { get; set; }
+        if (item.Name != null) device.Name = item.Name;
+        if (item.IpAddress != null) device.IpAddress = item.IpAddress;
+        if (item.AccountId.HasValue) device.AccountId = item.AccountId;
+        if (item.DeviceGroupId.HasValue) device.DeviceGroupId = item.DeviceGroupId;
+    }
 
-        [Column("name")]
-        public required string Name { get; set; }
+    public static void AssignGroupFrom(this Device device, DeviceAssignGroupItem item)
+    {
+        device.DeviceGroupId = item.DeviceGroupId;
+    }
 
-        [Column("ip_address")]
-        public required string IpAddress { get; set; }
-
-        [Column("account_id")]
-        public int? AccountId { get; set; }
-        public Account? Account { get; set; }
-
-        [Column("device_group_id")]
-        public int? DeviceGroupId { get; set; }
-        public DeviceGroup? DeviceGroup { get; set; }
-
-        public ICollection<Screenshot> Screenshots { get; set; } = [];
-        public ICollection<VideoAtDevice> VideoAtDevices { get; set; } = [];
+    public static void InitialAssignAccountFrom(this Device device, DeviceInitialAssignAccountItem item)
+    {
+        device.Name = item.Name;
+        device.AccountId = item.AccountId;
     }
 }
 

--- a/MediaPi.Core/RestModels/DeviceAssignGroupItem.cs
+++ b/MediaPi.Core/RestModels/DeviceAssignGroupItem.cs
@@ -20,32 +20,19 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-using System.ComponentModel.DataAnnotations.Schema;
+using System.Text.Json;
 
-namespace MediaPi.Core.Models
+using MediaPi.Core.Settings;
+
+namespace MediaPi.Core.RestModels;
+
+public class DeviceAssignGroupItem
 {
-    [Table("devices")]
-    public class Device
+    public int? DeviceGroupId { get; set; }
+
+    public override string ToString()
     {
-        [Column("id")]
-        public int Id { get; set; }
-
-        [Column("name")]
-        public required string Name { get; set; }
-
-        [Column("ip_address")]
-        public required string IpAddress { get; set; }
-
-        [Column("account_id")]
-        public int? AccountId { get; set; }
-        public Account? Account { get; set; }
-
-        [Column("device_group_id")]
-        public int? DeviceGroupId { get; set; }
-        public DeviceGroup? DeviceGroup { get; set; }
-
-        public ICollection<Screenshot> Screenshots { get; set; } = [];
-        public ICollection<VideoAtDevice> VideoAtDevices { get; set; } = [];
+        return JsonSerializer.Serialize(this, JOptions.DefaultOptions);
     }
 }
 

--- a/MediaPi.Core/RestModels/DeviceInitialAssignAccountItem.cs
+++ b/MediaPi.Core/RestModels/DeviceInitialAssignAccountItem.cs
@@ -20,32 +20,20 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-using System.ComponentModel.DataAnnotations.Schema;
+using System.Text.Json;
 
-namespace MediaPi.Core.Models
+using MediaPi.Core.Settings;
+
+namespace MediaPi.Core.RestModels;
+
+public class DeviceInitialAssignAccountItem
 {
-    [Table("devices")]
-    public class Device
+    public string Name { get; set; } = "";
+    public int AccountId { get; set; }
+
+    public override string ToString()
     {
-        [Column("id")]
-        public int Id { get; set; }
-
-        [Column("name")]
-        public required string Name { get; set; }
-
-        [Column("ip_address")]
-        public required string IpAddress { get; set; }
-
-        [Column("account_id")]
-        public int? AccountId { get; set; }
-        public Account? Account { get; set; }
-
-        [Column("device_group_id")]
-        public int? DeviceGroupId { get; set; }
-        public DeviceGroup? DeviceGroup { get; set; }
-
-        public ICollection<Screenshot> Screenshots { get; set; } = [];
-        public ICollection<VideoAtDevice> VideoAtDevices { get; set; } = [];
+        return JsonSerializer.Serialize(this, JOptions.DefaultOptions);
     }
 }
 

--- a/MediaPi.Core/RestModels/DeviceUpdateItem.cs
+++ b/MediaPi.Core/RestModels/DeviceUpdateItem.cs
@@ -20,32 +20,22 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-using System.ComponentModel.DataAnnotations.Schema;
+using System.Text.Json;
 
-namespace MediaPi.Core.Models
+using MediaPi.Core.Settings;
+
+namespace MediaPi.Core.RestModels;
+
+public class DeviceUpdateItem
 {
-    [Table("devices")]
-    public class Device
+    public string? Name { get; set; }
+    public string? IpAddress { get; set; }
+    public int? AccountId { get; set; }
+    public int? DeviceGroupId { get; set; }
+
+    public override string ToString()
     {
-        [Column("id")]
-        public int Id { get; set; }
-
-        [Column("name")]
-        public required string Name { get; set; }
-
-        [Column("ip_address")]
-        public required string IpAddress { get; set; }
-
-        [Column("account_id")]
-        public int? AccountId { get; set; }
-        public Account? Account { get; set; }
-
-        [Column("device_group_id")]
-        public int? DeviceGroupId { get; set; }
-        public DeviceGroup? DeviceGroup { get; set; }
-
-        public ICollection<Screenshot> Screenshots { get; set; } = [];
-        public ICollection<VideoAtDevice> VideoAtDevices { get; set; } = [];
+        return JsonSerializer.Serialize(this, JOptions.DefaultOptions);
     }
 }
 

--- a/MediaPi.Core/RestModels/DeviceViewItem.cs
+++ b/MediaPi.Core/RestModels/DeviceViewItem.cs
@@ -20,32 +20,24 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-using System.ComponentModel.DataAnnotations.Schema;
+using System.Text.Json;
 
-namespace MediaPi.Core.Models
+using MediaPi.Core.Models;
+using MediaPi.Core.Settings;
+
+namespace MediaPi.Core.RestModels;
+
+public class DeviceViewItem(Device device)
 {
-    [Table("devices")]
-    public class Device
+    public int Id { get; set; } = device.Id;
+    public string Name { get; set; } = device.Name;
+    public string IpAddress { get; set; } = device.IpAddress;
+    public int? AccountId { get; set; } = device.AccountId;
+    public int? DeviceGroupId { get; set; } = device.DeviceGroupId;
+
+    public override string ToString()
     {
-        [Column("id")]
-        public int Id { get; set; }
-
-        [Column("name")]
-        public required string Name { get; set; }
-
-        [Column("ip_address")]
-        public required string IpAddress { get; set; }
-
-        [Column("account_id")]
-        public int? AccountId { get; set; }
-        public Account? Account { get; set; }
-
-        [Column("device_group_id")]
-        public int? DeviceGroupId { get; set; }
-        public DeviceGroup? DeviceGroup { get; set; }
-
-        public ICollection<Screenshot> Screenshots { get; set; } = [];
-        public ICollection<VideoAtDevice> VideoAtDevices { get; set; } = [];
+        return JsonSerializer.Serialize(this, JOptions.DefaultOptions);
     }
 }
 


### PR DESCRIPTION
## Summary
- allow devices to have optional account association
- manage devices with registration, grouping and account assignment endpoints
- cover device operations with extensive unit tests

## Testing
- `dotnet test MediaPi.sln`


------
https://chatgpt.com/codex/tasks/task_e_688dd509b5b08321b0e35c50a5b02be8