### PR TITLE
Ensure unique device IPs and normalize IPv4-mapped addresses

### DIFF
--- a/MediaPi.Core.Tests/Controllers/DevicesControllerTests.cs
+++ b/MediaPi.Core.Tests/Controllers/DevicesControllerTests.cs
@@ -151,6 +151,30 @@ public class DevicesControllerTests
     }
 
     [Test]
+    public async Task Register_Ipv4Mapped_IpStoredAsIpv4()
+    {
+        SetCurrentUser(null, "::ffff:9.8.7.6");
+        var result = await _controller.Register();
+        var created = result.Result as CreatedAtActionResult;
+        Assert.That(created, Is.Not.Null);
+        var reference = created!.Value as Reference;
+        Assert.That(reference, Is.Not.Null);
+        var dev = await _dbContext.Devices.FindAsync(reference!.Id);
+        Assert.That(dev, Is.Not.Null);
+        Assert.That(dev!.IpAddress, Is.EqualTo("9.8.7.6"));
+    }
+
+    [Test]
+    public async Task Register_DuplicateIp_ReturnsConflict()
+    {
+        SetCurrentUser(null, "1.1.1.1");
+        var result = await _controller.Register();
+        Assert.That(result.Result, Is.TypeOf<ObjectResult>());
+        var obj = result.Result as ObjectResult;
+        Assert.That(obj!.StatusCode, Is.EqualTo(StatusCodes.Status409Conflict));
+    }
+
+    [Test]
     public async Task GetAll_Admin_ReturnsAll()
     {
         SetCurrentUser(1);
@@ -235,6 +259,28 @@ public class DevicesControllerTests
         Assert.That(response, Is.TypeOf<NoContentResult>());
         var dev = await _dbContext.Devices.FindAsync(1);
         Assert.That(dev!.IpAddress, Is.EqualTo("10.0.0.1"));
+    }
+
+    [Test]
+    public async Task Update_Admin_Ipv4MappedIp_StoredAsIpv4()
+    {
+        SetCurrentUser(1);
+        var dto = new DeviceUpdateItem { IpAddress = "::ffff:10.0.0.2" };
+        var response = await _controller.UpdateDevice(1, dto);
+        Assert.That(response, Is.TypeOf<NoContentResult>());
+        var dev = await _dbContext.Devices.FindAsync(1);
+        Assert.That(dev!.IpAddress, Is.EqualTo("10.0.0.2"));
+    }
+
+    [Test]
+    public async Task Update_Admin_DuplicateIp_ReturnsConflict()
+    {
+        SetCurrentUser(1);
+        var dto = new DeviceUpdateItem { IpAddress = "2.2.2.2" }; // existing ip of device 2
+        var response = await _controller.UpdateDevice(1, dto);
+        Assert.That(response, Is.TypeOf<ObjectResult>());
+        var obj = response as ObjectResult;
+        Assert.That(obj!.StatusCode, Is.EqualTo(StatusCodes.Status409Conflict));
     }
 
     [Test]

--- a/MediaPi.Core/Controllers/MediaPiControllerBase.cs
+++ b/MediaPi.Core/Controllers/MediaPiControllerBase.cs
@@ -82,6 +82,12 @@ public class FuelfluxControllerPreBase(AppDbContext db, ILogger logger) : Contro
                           new ErrMessage { Msg = $"Пользователь с таким адресом электронной почты уже зарегистрирован [email = {email}]" });
     }
 
+    protected ObjectResult _409Ip(string ip)
+    {
+        return StatusCode(StatusCodes.Status409Conflict,
+                          new ErrMessage { Msg = $"Устройство с таким IP адресом уже зарегистрировано [ip = {ip}]" });
+    }
+
     protected ObjectResult _400Ip(string ip)
     {
         return StatusCode(StatusCodes.Status400BadRequest,

--- a/MediaPi.Core/Data/AppDbContext.cs
+++ b/MediaPi.Core/Data/AppDbContext.cs
@@ -131,6 +131,10 @@ namespace MediaPi.Core.Data
                 .WithMany(g => g.Devices)
                 .HasForeignKey(d => d.DeviceGroupId);
 
+            modelBuilder.Entity<Device>()
+                .HasIndex(d => d.IpAddress)
+                .IsUnique();
+
             modelBuilder.Entity<VideoStatus>().HasData(
                 new VideoStatus { Id = StatusConstants.Queued, Name = "Queued" },
                 new VideoStatus { Id = StatusConstants.Loading, Name = "Loading" },

--- a/MediaPi.Core/Extensions/DeviceExtensions.cs
+++ b/MediaPi.Core/Extensions/DeviceExtensions.cs
@@ -32,7 +32,6 @@ public static class DeviceExtensions
     public static void UpdateFrom(this Device device, DeviceUpdateItem item)
     {
         if (item.Name != null) device.Name = item.Name;
-        if (item.IpAddress != null) device.IpAddress = item.IpAddress;
         if (item.AccountId.HasValue) device.AccountId = item.AccountId;
         if (item.DeviceGroupId.HasValue) device.DeviceGroupId = item.DeviceGroupId;
     }

--- a/MediaPi.Core/Migrations/20250802093324_UniqueDeviceIp.Designer.cs
+++ b/MediaPi.Core/Migrations/20250802093324_UniqueDeviceIp.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using MediaPi.Core.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace MediaPi.Core.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250802093324_UniqueDeviceIp")]
+    partial class UniqueDeviceIp
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/MediaPi.Core/Migrations/20250802093324_UniqueDeviceIp.cs
+++ b/MediaPi.Core/Migrations/20250802093324_UniqueDeviceIp.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace MediaPi.Core.Migrations
+{
+    /// <inheritdoc />
+    public partial class UniqueDeviceIp : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateIndex(
+                name: "IX_devices_ip_address",
+                table: "devices",
+                column: "ip_address",
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_devices_ip_address",
+                table: "devices");
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Enforce a unique index on device IP addresses and expose 409 conflict response for duplicates
- Normalize IPv4-mapped IPv6 addresses during device registration and updates
- Extend controller tests to cover IPv4 mapping and duplicate IP scenarios

## Testing
- `dotnet test MediaPi.sln`

------
https://chatgpt.com/codex/tasks/task_e_688dda78ceb48321bdf3c7f63666b028