### PR TITLE
Prevent device registration without IP

### DIFF
--- a/MediaPi.Core.Tests/Controllers/DevicesControllerTests.cs
+++ b/MediaPi.Core.Tests/Controllers/DevicesControllerTests.cs
@@ -175,6 +175,16 @@ public class DevicesControllerTests
     }
 
     [Test]
+    public async Task Register_NoIp_ReturnsBadRequest()
+    {
+        SetCurrentUser(null);
+        var result = await _controller.Register();
+        Assert.That(result.Result, Is.TypeOf<ObjectResult>());
+        var obj = result.Result as ObjectResult;
+        Assert.That(obj!.StatusCode, Is.EqualTo(StatusCodes.Status400BadRequest));
+    }
+
+    [Test]
     public async Task GetAll_Admin_ReturnsAll()
     {
         SetCurrentUser(1);

--- a/MediaPi.Core/Controllers/DevicesController.cs
+++ b/MediaPi.Core/Controllers/DevicesController.cs
@@ -72,6 +72,8 @@ public class DevicesController(
         }
         var ip = ipAddress?.ToString() ?? "";
 
+        if (string.IsNullOrWhiteSpace(ip)) return _400Ip(ip);
+
         if (await _db.Devices.AnyAsync(d => d.IpAddress == ip)) return _409Ip(ip);
 
         var device = new Device { Name = string.Empty, IpAddress = ip };


### PR DESCRIPTION
## Summary
- reject device registration when no remote IP is provided
- add test verifying empty IP registration is rejected

## Testing
- `dotnet test MediaPi.sln`


------
https://chatgpt.com/codex/tasks/task_e_688ddd02059083218571acdf367b0dc0