### PR TITLE
Add DeviceGroup controller with role-based CRUD operations

### DIFF
--- a/MediaPi.Core.Tests/Controllers/DeviceGroupsControllerTests.cs
+++ b/MediaPi.Core.Tests/Controllers/DeviceGroupsControllerTests.cs
@@ -1,0 +1,196 @@
+// MIT License
+//
+// Copyright (c) 2025 Maxim [maxirmx] Samsonov (www.sw.consulting)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+
+using Moq;
+using NUnit.Framework;
+
+using System.Linq;
+using System.Threading.Tasks;
+
+using MediaPi.Core.Controllers;
+using MediaPi.Core.Data;
+using MediaPi.Core.Models;
+using MediaPi.Core.RestModels;
+
+namespace MediaPi.Core.Tests.Controllers;
+
+[TestFixture]
+public class DeviceGroupsControllerTests
+{
+#pragma warning disable CS8618
+    private Mock<IHttpContextAccessor> _mockHttpContextAccessor;
+    private Mock<ILogger<DeviceGroupsController>> _mockLogger;
+    private AppDbContext _dbContext;
+    private DeviceGroupsController _controller;
+    private User _admin;
+    private User _manager;
+    private Role _adminRole;
+    private Role _managerRole;
+    private Account _account1;
+    private Account _account2;
+    private DeviceGroup _group1;
+    private DeviceGroup _group2;
+    private Device _device1;
+#pragma warning restore CS8618
+
+    [SetUp]
+    public void Setup()
+    {
+        var options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase($"device_group_controller_test_db_{System.Guid.NewGuid()}")
+            .Options;
+
+        _dbContext = new AppDbContext(options);
+
+        _adminRole = new Role { RoleId = UserRoleConstants.SystemAdministrator, Name = "Admin" };
+        _managerRole = new Role { RoleId = UserRoleConstants.AccountManager, Name = "Manager" };
+        _dbContext.Roles.AddRange(_adminRole, _managerRole);
+
+        _account1 = new Account { Id = 1, Name = "Acc1" };
+        _account2 = new Account { Id = 2, Name = "Acc2" };
+        _dbContext.Accounts.AddRange(_account1, _account2);
+
+        _group1 = new DeviceGroup { Id = 1, Name = "Grp1", AccountId = _account1.Id, Account = _account1 };
+        _group2 = new DeviceGroup { Id = 2, Name = "Grp2", AccountId = _account2.Id, Account = _account2 };
+        _dbContext.DeviceGroups.AddRange(_group1, _group2);
+
+        _device1 = new Device { Id = 1, Name = "Dev1", IpAddress = "1.1.1.1", AccountId = _account1.Id, DeviceGroupId = _group1.Id };
+        _dbContext.Devices.Add(_device1);
+
+        string pass = BCrypt.Net.BCrypt.HashPassword("pwd");
+
+        _admin = new User
+        {
+            Id = 1,
+            Email = "admin@example.com",
+            Password = pass,
+            UserRoles = [ new UserRole { UserId = 1, RoleId = _adminRole.Id, Role = _adminRole } ]
+        };
+
+        _manager = new User
+        {
+            Id = 2,
+            Email = "manager@example.com",
+            Password = pass,
+            UserRoles = [ new UserRole { UserId = 2, RoleId = _managerRole.Id, Role = _managerRole } ],
+            UserAccounts = [ new UserAccount { UserId = 2, AccountId = _account1.Id, Account = _account1 } ]
+        };
+
+        _dbContext.Users.AddRange(_admin, _manager);
+        _dbContext.SaveChanges();
+
+        _mockHttpContextAccessor = new Mock<IHttpContextAccessor>();
+        _mockLogger = new Mock<ILogger<DeviceGroupsController>>();
+    }
+
+    private void SetCurrentUser(int? id)
+    {
+        var context = new DefaultHttpContext();
+        if (id.HasValue) context.Items["UserId"] = id.Value;
+        _mockHttpContextAccessor.Setup(x => x.HttpContext).Returns(context);
+        _controller = new DeviceGroupsController(_mockHttpContextAccessor.Object, _dbContext, _mockLogger.Object)
+        {
+            ControllerContext = new ControllerContext { HttpContext = context }
+        };
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        _dbContext.Database.EnsureDeleted();
+        _dbContext.Dispose();
+    }
+
+    [Test]
+    public async Task GetAll_Admin_ReturnsAll()
+    {
+        SetCurrentUser(1);
+        var result = await _controller.GetAll();
+        Assert.That(result.Value, Is.Not.Null);
+        Assert.That(result.Value!.Count(), Is.EqualTo(2));
+    }
+
+    [Test]
+    public async Task GetAll_Manager_ReturnsOwn()
+    {
+        SetCurrentUser(2);
+        var result = await _controller.GetAll();
+        Assert.That(result.Value, Is.Not.Null);
+        Assert.That(result.Value!.Count(), Is.EqualTo(1));
+        Assert.That(result.Value!.First().Id, Is.EqualTo(_group1.Id));
+    }
+
+    [Test]
+    public async Task GetGroup_Manager_Other_Forbidden()
+    {
+        SetCurrentUser(2);
+        var result = await _controller.GetGroup(_group2.Id);
+        Assert.That(result.Result, Is.TypeOf<ObjectResult>());
+        var obj = result.Result as ObjectResult;
+        Assert.That(obj!.StatusCode, Is.EqualTo(StatusCodes.Status403Forbidden));
+    }
+
+    [Test]
+    public async Task PostGroup_Manager_AccountOverridden()
+    {
+        SetCurrentUser(2);
+        var dto = new DeviceGroupCreateItem { Name = "NewGrp", AccountId = _account2.Id };
+        var result = await _controller.PostGroup(dto);
+        var created = result.Result as CreatedAtActionResult;
+        Assert.That(created, Is.Not.Null);
+        var reference = created!.Value as Reference;
+        Assert.That(reference, Is.Not.Null);
+        var grp = await _dbContext.DeviceGroups.FindAsync(reference!.Id);
+        Assert.That(grp, Is.Not.Null);
+        Assert.That(grp!.AccountId, Is.EqualTo(_account1.Id));
+    }
+
+    [Test]
+    public async Task UpdateGroup_Manager_CannotChangeAccount()
+    {
+        SetCurrentUser(2);
+        var dto = new DeviceGroupUpdateItem { Name = "Renamed", AccountId = _account2.Id };
+        var result = await _controller.UpdateGroup(_group1.Id, dto);
+        Assert.That(result, Is.TypeOf<NoContentResult>());
+        var grp = await _dbContext.DeviceGroups.FindAsync(_group1.Id);
+        Assert.That(grp!.AccountId, Is.EqualTo(_account1.Id));
+        Assert.That(grp.Name, Is.EqualTo("Renamed"));
+    }
+
+    [Test]
+    public async Task DeleteGroup_Admin_SetsDeviceNull()
+    {
+        SetCurrentUser(1);
+        var result = await _controller.DeleteGroup(_group1.Id);
+        Assert.That(result, Is.TypeOf<NoContentResult>());
+        var dev = await _dbContext.Devices.FindAsync(_device1.Id);
+        Assert.That(dev!.DeviceGroupId, Is.Null);
+        var grp = await _dbContext.DeviceGroups.FindAsync(_group1.Id);
+        Assert.That(grp, Is.Null);
+    }
+}
+

--- a/MediaPi.Core/Controllers/DeviceGroupsController.cs
+++ b/MediaPi.Core/Controllers/DeviceGroupsController.cs
@@ -1,0 +1,210 @@
+// MIT License
+//
+// Copyright (c) 2025 Maxim [maxirmx] Samsonov (www.sw.consulting)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+
+using MediaPi.Core.Authorization;
+using MediaPi.Core.Data;
+using MediaPi.Core.Models;
+using MediaPi.Core.RestModels;
+using MediaPi.Core.Extensions;
+
+namespace MediaPi.Core.Controllers;
+
+[ApiController]
+[Authorize]
+[Route("api/[controller]")]
+[Produces("application/json")]
+[ProducesResponseType(StatusCodes.Status401Unauthorized, Type = typeof(ErrMessage))]
+public class DeviceGroupsController(
+    IHttpContextAccessor httpContextAccessor,
+    AppDbContext db,
+    ILogger<DeviceGroupsController> logger) : MediaPiControllerBase(httpContextAccessor, db, logger)
+{
+    private async Task<User?> CurrentUser()
+    {
+        return await _db.Users
+            .Include(u => u.UserRoles).ThenInclude(ur => ur.Role)
+            .Include(u => u.UserAccounts)
+            .FirstOrDefaultAsync(u => u.Id == _curUserId);
+    }
+
+    private static List<int> GetUserAccountIds(User user)
+    {
+        return [.. user.UserAccounts.Select(ua => ua.AccountId)];
+    }
+
+    private static bool ManagerOwnsGroup(User user, DeviceGroup group)
+    {
+        if (!user.IsManager()) return false;
+        var accountIds = GetUserAccountIds(user);
+        return accountIds.Contains(group.AccountId);
+    }
+
+    // GET: api/devicegroups
+    [HttpGet]
+    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(IEnumerable<DeviceGroupViewItem>))]
+    [ProducesResponseType(StatusCodes.Status403Forbidden, Type = typeof(ErrMessage))]
+    public async Task<ActionResult<IEnumerable<DeviceGroupViewItem>>> GetAll()
+    {
+        var user = await CurrentUser();
+        if (user == null) return _403();
+
+        IQueryable<DeviceGroup> query = _db.DeviceGroups;
+        if (user.IsAdministrator())
+        {
+            // all groups
+        }
+        else if (user.IsManager())
+        {
+            var accountIds = GetUserAccountIds(user);
+            query = query.Where(g => accountIds.Contains(g.AccountId));
+        }
+        else
+        {
+            return _403();
+        }
+
+        var groups = await query.ToListAsync();
+        return groups.Select(g => g.ToViewItem()).ToList();
+    }
+
+    // GET: api/devicegroups/{id}
+    [HttpGet("{id}")]
+    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(DeviceGroupViewItem))]
+    [ProducesResponseType(StatusCodes.Status403Forbidden, Type = typeof(ErrMessage))]
+    [ProducesResponseType(StatusCodes.Status404NotFound, Type = typeof(ErrMessage))]
+    public async Task<ActionResult<DeviceGroupViewItem>> GetGroup(int id)
+    {
+        var user = await CurrentUser();
+        if (user == null) return _403();
+
+        var group = await _db.DeviceGroups.FindAsync(id);
+        if (group == null) return _404DeviceGroup(id);
+
+        if (user.IsAdministrator() || ManagerOwnsGroup(user, group))
+        {
+            return group.ToViewItem();
+        }
+
+        return _403();
+    }
+
+    // POST: api/devicegroups
+    [HttpPost]
+    [ProducesResponseType(StatusCodes.Status201Created, Type = typeof(Reference))]
+    [ProducesResponseType(StatusCodes.Status403Forbidden, Type = typeof(ErrMessage))]
+    [ProducesResponseType(StatusCodes.Status404NotFound, Type = typeof(ErrMessage))]
+    public async Task<ActionResult<Reference>> PostGroup(DeviceGroupCreateItem item)
+    {
+        var user = await CurrentUser();
+        if (user == null) return _403();
+
+        int accountId;
+        if (user.IsAdministrator())
+        {
+            if (!await _db.Accounts.AnyAsync(a => a.Id == item.AccountId)) return _404Account(item.AccountId);
+            accountId = item.AccountId;
+        }
+        else if (user.IsManager())
+        {
+            var accountIds = GetUserAccountIds(user);
+            if (accountIds.Count == 0) return _403();
+            accountId = accountIds[0];
+        }
+        else
+        {
+            return _403();
+        }
+
+        var group = new DeviceGroup { Name = item.Name, AccountId = accountId };
+        _db.DeviceGroups.Add(group);
+        await _db.SaveChangesAsync();
+        return CreatedAtAction(nameof(GetGroup), new { id = group.Id }, new Reference { Id = group.Id });
+    }
+
+    // PUT: api/devicegroups/{id}
+    [HttpPut("{id}")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden, Type = typeof(ErrMessage))]
+    [ProducesResponseType(StatusCodes.Status404NotFound, Type = typeof(ErrMessage))]
+    public async Task<IActionResult> UpdateGroup(int id, DeviceGroupUpdateItem item)
+    {
+        var user = await CurrentUser();
+        if (user == null) return _403();
+
+        var group = await _db.DeviceGroups.FindAsync(id);
+        if (group == null) return _404DeviceGroup(id);
+
+        if (user.IsAdministrator())
+        {
+            if (item.AccountId.HasValue)
+            {
+                if (!await _db.Accounts.AnyAsync(a => a.Id == item.AccountId.Value)) return _404Account(item.AccountId.Value);
+                group.AccountId = item.AccountId.Value;
+            }
+        }
+        else if (ManagerOwnsGroup(user, group))
+        {
+            // Account operators cannot change accountId
+        }
+        else
+        {
+            return _403();
+        }
+
+        if (item.Name != null) group.Name = item.Name;
+
+        _db.Entry(group).State = EntityState.Modified;
+        await _db.SaveChangesAsync();
+
+        return NoContent();
+    }
+
+    // DELETE: api/devicegroups/{id}
+    [HttpDelete("{id}")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden, Type = typeof(ErrMessage))]
+    [ProducesResponseType(StatusCodes.Status404NotFound, Type = typeof(ErrMessage))]
+    public async Task<IActionResult> DeleteGroup(int id)
+    {
+        var user = await CurrentUser();
+        if (user == null) return _403();
+
+        var group = await _db.DeviceGroups.Include(g => g.Devices).FirstOrDefaultAsync(g => g.Id == id);
+        if (group == null) return _404DeviceGroup(id);
+
+        if (!(user.IsAdministrator() || ManagerOwnsGroup(user, group))) return _403();
+
+        foreach (var device in group.Devices)
+        {
+            device.DeviceGroupId = null;
+        }
+
+        _db.DeviceGroups.Remove(group);
+        await _db.SaveChangesAsync();
+
+        return NoContent();
+    }
+}
+

--- a/MediaPi.Core/Controllers/MediaPiControllerBase.cs
+++ b/MediaPi.Core/Controllers/MediaPiControllerBase.cs
@@ -76,6 +76,16 @@ public class FuelfluxControllerPreBase(AppDbContext db, ILogger logger) : Contro
         return StatusCode(StatusCodes.Status404NotFound,
                           new ErrMessage { Msg = $"Не удалось найти устройство [id={id}]" });
     }
+    protected ObjectResult _404DeviceGroup(int id)
+    {
+        return StatusCode(StatusCodes.Status404NotFound,
+                          new ErrMessage { Msg = $"Не удалось найти группу устройств [id={id}]" });
+    }
+    protected ObjectResult _404Account(int id)
+    {
+        return StatusCode(StatusCodes.Status404NotFound,
+                          new ErrMessage { Msg = $"Не удалось найти лицевой счёт [id={id}]" });
+    }
     protected ObjectResult _409Email(string email)
     {
         return StatusCode(StatusCodes.Status409Conflict,

--- a/MediaPi.Core/Extensions/DeviceGroupExtensions.cs
+++ b/MediaPi.Core/Extensions/DeviceGroupExtensions.cs
@@ -1,0 +1,38 @@
+// MIT License
+//
+// Copyright (c) 2025 Maxim [maxirmx] Samsonov (www.sw.consulting)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using MediaPi.Core.Models;
+using MediaPi.Core.RestModels;
+
+namespace MediaPi.Core.Extensions;
+
+public static class DeviceGroupExtensions
+{
+    public static DeviceGroupViewItem ToViewItem(this DeviceGroup group) => new(group);
+
+    public static void UpdateFrom(this DeviceGroup group, DeviceGroupUpdateItem item)
+    {
+        if (item.Name != null) group.Name = item.Name;
+        if (item.AccountId.HasValue) group.AccountId = item.AccountId.Value;
+    }
+}
+

--- a/MediaPi.Core/RestModels/DeviceGroupCreateItem.cs
+++ b/MediaPi.Core/RestModels/DeviceGroupCreateItem.cs
@@ -1,0 +1,39 @@
+// MIT License
+//
+// Copyright (c) 2025 Maxim [maxirmx] Samsonov (www.sw.consulting)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System.Text.Json;
+
+using MediaPi.Core.Settings;
+
+namespace MediaPi.Core.RestModels;
+
+public class DeviceGroupCreateItem
+{
+    public string Name { get; set; } = string.Empty;
+    public int AccountId { get; set; }
+
+    public override string ToString()
+    {
+        return JsonSerializer.Serialize(this, JOptions.DefaultOptions);
+    }
+}
+

--- a/MediaPi.Core/RestModels/DeviceGroupUpdateItem.cs
+++ b/MediaPi.Core/RestModels/DeviceGroupUpdateItem.cs
@@ -1,0 +1,39 @@
+// MIT License
+//
+// Copyright (c) 2025 Maxim [maxirmx] Samsonov (www.sw.consulting)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System.Text.Json;
+
+using MediaPi.Core.Settings;
+
+namespace MediaPi.Core.RestModels;
+
+public class DeviceGroupUpdateItem
+{
+    public string? Name { get; set; }
+    public int? AccountId { get; set; }
+
+    public override string ToString()
+    {
+        return JsonSerializer.Serialize(this, JOptions.DefaultOptions);
+    }
+}
+

--- a/MediaPi.Core/RestModels/DeviceGroupViewItem.cs
+++ b/MediaPi.Core/RestModels/DeviceGroupViewItem.cs
@@ -1,0 +1,41 @@
+// MIT License
+//
+// Copyright (c) 2025 Maxim [maxirmx] Samsonov (www.sw.consulting)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System.Text.Json;
+
+using MediaPi.Core.Models;
+using MediaPi.Core.Settings;
+
+namespace MediaPi.Core.RestModels;
+
+public class DeviceGroupViewItem(DeviceGroup group)
+{
+    public int Id { get; set; } = group.Id;
+    public string Name { get; set; } = group.Name;
+    public int AccountId { get; set; } = group.AccountId;
+
+    public override string ToString()
+    {
+        return JsonSerializer.Serialize(this, JOptions.DefaultOptions);
+    }
+}
+


### PR DESCRIPTION
## Summary
- add DeviceGroupsController with CRUD endpoints and role-based access rules
- introduce DeviceGroup DTOs and extensions
- ensure deleting a device group unassigns its devices
- add _404DeviceGroup and _404Account helpers
- cover new behavior with unit tests

## Testing
- `dotnet test MediaPi.sln`

------
https://chatgpt.com/codex/tasks/task_e_688df1880ae08321b7fb7d426bf6766b