### PR TITLE
Implement account management controller with proper deletion handling

### DIFF
--- a/MediaPi.Core.Tests/Controllers/AccountsControllerTests.cs
+++ b/MediaPi.Core.Tests/Controllers/AccountsControllerTests.cs
@@ -1,0 +1,194 @@
+// MIT License
+//
+// Copyright (c) 2025 Maxim [maxirmx] Samsonov (www.sw.consulting)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Moq;
+using NUnit.Framework;
+using System.Linq;
+using System.Threading.Tasks;
+using MediaPi.Core.Controllers;
+using MediaPi.Core.Data;
+using MediaPi.Core.Models;
+using MediaPi.Core.RestModels;
+using MediaPi.Core.Services;
+
+namespace MediaPi.Core.Tests.Controllers;
+
+[TestFixture]
+public class AccountsControllerTests
+{
+#pragma warning disable CS8618
+    private Mock<IHttpContextAccessor> _mockHttpContextAccessor;
+    private Mock<ILogger<AccountsController>> _mockLogger;
+    private AppDbContext _dbContext;
+    private AccountsController _controller;
+    private User _admin;
+    private User _manager;
+    private Role _adminRole;
+    private Role _managerRole;
+    private Account _account1;
+    private Account _account2;
+    private DeviceGroup _group1;
+    private Device _device1;
+    private UserInformationService _userInformationService;
+#pragma warning restore CS8618
+
+    [SetUp]
+    public void Setup()
+    {
+        var options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase($"accounts_controller_test_db_{System.Guid.NewGuid()}")
+            .Options;
+        _dbContext = new AppDbContext(options);
+
+        _adminRole = new Role { RoleId = UserRoleConstants.SystemAdministrator, Name = "Admin" };
+        _managerRole = new Role { RoleId = UserRoleConstants.AccountManager, Name = "Manager" };
+        _dbContext.Roles.AddRange(_adminRole, _managerRole);
+
+        _account1 = new Account { Id = 1, Name = "Acc1" };
+        _account2 = new Account { Id = 2, Name = "Acc2" };
+        _dbContext.Accounts.AddRange(_account1, _account2);
+
+        _group1 = new DeviceGroup { Id = 1, Name = "Grp1", AccountId = _account1.Id, Account = _account1 };
+        _dbContext.DeviceGroups.Add(_group1);
+
+        _device1 = new Device { Id = 1, Name = "Dev1", IpAddress = "1.1.1.1", AccountId = _account1.Id, DeviceGroupId = _group1.Id };
+        _dbContext.Devices.Add(_device1);
+
+        string pass = BCrypt.Net.BCrypt.HashPassword("pwd");
+
+        _admin = new User
+        {
+            Id = 1,
+            Email = "admin@example.com",
+            Password = pass,
+            UserRoles = [ new UserRole { UserId = 1, RoleId = _adminRole.Id, Role = _adminRole } ]
+        };
+
+        _manager = new User
+        {
+            Id = 2,
+            Email = "manager@example.com",
+            Password = pass,
+            UserRoles = [ new UserRole { UserId = 2, RoleId = _managerRole.Id, Role = _managerRole } ],
+            UserAccounts = [ new UserAccount { UserId = 2, AccountId = _account1.Id, Account = _account1 } ]
+        };
+
+        _dbContext.Users.AddRange(_admin, _manager);
+        _dbContext.SaveChanges();
+
+        _mockHttpContextAccessor = new Mock<IHttpContextAccessor>();
+        _mockLogger = new Mock<ILogger<AccountsController>>();
+        _userInformationService = new UserInformationService(_dbContext);
+    }
+
+    private void SetCurrentUser(int? id)
+    {
+        var context = new DefaultHttpContext();
+        if (id.HasValue) context.Items["UserId"] = id.Value;
+        _mockHttpContextAccessor.Setup(x => x.HttpContext).Returns(context);
+        _controller = new AccountsController(
+            _mockHttpContextAccessor.Object,
+            _userInformationService,
+            _dbContext,
+            _mockLogger.Object)
+        {
+            ControllerContext = new ControllerContext { HttpContext = context }
+        };
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        _dbContext.Database.EnsureDeleted();
+        _dbContext.Dispose();
+    }
+
+    [Test]
+    public async Task GetAll_Admin_ReturnsAll()
+    {
+        SetCurrentUser(1);
+        var result = await _controller.GetAll();
+        Assert.That(result.Value, Is.Not.Null);
+        Assert.That(result.Value!.Count(), Is.EqualTo(2));
+    }
+
+    [Test]
+    public async Task GetAll_Manager_ReturnsOwn()
+    {
+        SetCurrentUser(2);
+        var result = await _controller.GetAll();
+        Assert.That(result.Value, Is.Not.Null);
+        Assert.That(result.Value!.Count(), Is.EqualTo(1));
+        Assert.That(result.Value!.First().Id, Is.EqualTo(_account1.Id));
+    }
+
+    [Test]
+    public async Task GetAccount_Manager_Other_Forbidden()
+    {
+        SetCurrentUser(2);
+        var result = await _controller.GetAccount(_account2.Id);
+        Assert.That(result.Result, Is.TypeOf<ObjectResult>());
+        var obj = result.Result as ObjectResult;
+        Assert.That(obj!.StatusCode, Is.EqualTo(StatusCodes.Status403Forbidden));
+    }
+
+    [Test]
+    public async Task PostAccount_Admin_Creates()
+    {
+        SetCurrentUser(1);
+        var dto = new AccountCreateItem { Name = "NewAcc" };
+        var result = await _controller.PostAccount(dto);
+        Assert.That(result.Result, Is.TypeOf<CreatedAtActionResult>());
+        Assert.That(_dbContext.Accounts.Count(), Is.EqualTo(3));
+    }
+
+    [Test]
+    public async Task PostAccount_Manager_Forbidden()
+    {
+        SetCurrentUser(2);
+        var dto = new AccountCreateItem { Name = "NewAcc" };
+        var result = await _controller.PostAccount(dto);
+        Assert.That(result.Result, Is.TypeOf<ObjectResult>());
+        var obj = result.Result as ObjectResult;
+        Assert.That(obj!.StatusCode, Is.EqualTo(StatusCodes.Status403Forbidden));
+    }
+
+    [Test]
+    public async Task DeleteAccount_Admin_SetsDeviceNull()
+    {
+        SetCurrentUser(1);
+        var result = await _controller.DeleteAccount(_account1.Id);
+        Assert.That(result, Is.TypeOf<NoContentResult>());
+        var dev = await _dbContext.Devices.FindAsync(_device1.Id);
+        Assert.That(dev!.AccountId, Is.Null);
+        Assert.That(dev.DeviceGroupId, Is.Null);
+        var grp = await _dbContext.DeviceGroups.FindAsync(_group1.Id);
+        Assert.That(grp, Is.Null);
+        var acc = await _dbContext.Accounts.FindAsync(_account1.Id);
+        Assert.That(acc, Is.Null);
+    }
+}
+

--- a/MediaPi.Core/Controllers/AccountsController.cs
+++ b/MediaPi.Core/Controllers/AccountsController.cs
@@ -156,12 +156,6 @@ public class AccountsController(
             .FirstOrDefaultAsync(a => a.Id == id);
         if (account == null) return _404Account(id);
 
-        foreach (var device in account.Devices)
-        {
-            device.AccountId = null;
-            device.DeviceGroupId = null;
-        }
-
         _db.DeviceGroups.RemoveRange(account.DeviceGroups);
         _db.Videos.RemoveRange(account.Videos);
         _db.Playlists.RemoveRange(account.Playlists);

--- a/MediaPi.Core/Controllers/AccountsController.cs
+++ b/MediaPi.Core/Controllers/AccountsController.cs
@@ -1,0 +1,176 @@
+// MIT License
+//
+// Copyright (c) 2025 Maxim [maxirmx] Samsonov (www.sw.consulting)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using MediaPi.Core.Authorization;
+using MediaPi.Core.Data;
+using MediaPi.Core.Extensions;
+using MediaPi.Core.Models;
+using MediaPi.Core.RestModels;
+using MediaPi.Core.Services;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+
+namespace MediaPi.Core.Controllers;
+
+[ApiController]
+[Authorize]
+[Route("api/[controller]")]
+[Produces("application/json")]
+[ProducesResponseType(StatusCodes.Status401Unauthorized, Type = typeof(ErrMessage))]
+public class AccountsController(
+    IHttpContextAccessor httpContextAccessor,
+    IUserInformationService userInformationService,
+    AppDbContext db,
+    ILogger<AccountsController> logger) : MediaPiControllerBase(httpContextAccessor, db, logger)
+{
+    private readonly IUserInformationService _userInformationService = userInformationService;
+
+    // GET: api/accounts
+    [HttpGet]
+    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(IEnumerable<AccountViewItem>))]
+    [ProducesResponseType(StatusCodes.Status403Forbidden, Type = typeof(ErrMessage))]
+    public async Task<ActionResult<IEnumerable<AccountViewItem>>> GetAll()
+    {
+        var user = await CurrentUser();
+        if (user == null) return _403();
+
+        IQueryable<Account> query = _db.Accounts;
+        if (user.IsAdministrator())
+        {
+            // all accounts
+        }
+        else if (user.IsManager())
+        {
+            var accountIds = _userInformationService.GetUserAccountIds(user);
+            query = query.Where(a => accountIds.Contains(a.Id));
+        }
+        else
+        {
+            return _403();
+        }
+
+        var accounts = await query.ToListAsync();
+        return accounts.Select(a => a.ToViewItem()).ToList();
+    }
+
+    // GET: api/accounts/{id}
+    [HttpGet("{id}")]
+    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(AccountViewItem))]
+    [ProducesResponseType(StatusCodes.Status403Forbidden, Type = typeof(ErrMessage))]
+    [ProducesResponseType(StatusCodes.Status404NotFound, Type = typeof(ErrMessage))]
+    public async Task<ActionResult<AccountViewItem>> GetAccount(int id)
+    {
+        var user = await CurrentUser();
+        if (user == null) return _403();
+
+        var account = await _db.Accounts.FindAsync(id);
+        if (account == null) return _404Account(id);
+
+        if (user.IsAdministrator() || _userInformationService.ManagerOwnsAccount(user, account))
+        {
+            return account.ToViewItem();
+        }
+
+        return _403();
+    }
+
+    // POST: api/accounts
+    [HttpPost]
+    [ProducesResponseType(StatusCodes.Status201Created, Type = typeof(Reference))]
+    [ProducesResponseType(StatusCodes.Status403Forbidden, Type = typeof(ErrMessage))]
+    [ProducesResponseType(StatusCodes.Status409Conflict, Type = typeof(ErrMessage))]
+    public async Task<ActionResult<Reference>> PostAccount(AccountCreateItem item)
+    {
+        var user = await CurrentUser();
+        if (user == null || !user.IsAdministrator()) return _403();
+
+        if (await _db.Accounts.AnyAsync(a => a.Name == item.Name)) return _409Account(item.Name);
+
+        var account = new Account { Name = item.Name };
+        _db.Accounts.Add(account);
+        await _db.SaveChangesAsync();
+        return CreatedAtAction(nameof(GetAccount), new { id = account.Id }, new Reference { Id = account.Id });
+    }
+
+    // PUT: api/accounts/{id}
+    [HttpPut("{id}")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden, Type = typeof(ErrMessage))]
+    [ProducesResponseType(StatusCodes.Status404NotFound, Type = typeof(ErrMessage))]
+    [ProducesResponseType(StatusCodes.Status409Conflict, Type = typeof(ErrMessage))]
+    public async Task<IActionResult> UpdateAccount(int id, AccountUpdateItem item)
+    {
+        var user = await CurrentUser();
+        if (user == null || !user.IsAdministrator()) return _403();
+
+        var account = await _db.Accounts.FindAsync(id);
+        if (account == null) return _404Account(id);
+
+        if (item.Name != null && await _db.Accounts.AnyAsync(a => a.Name == item.Name && a.Id != id))
+        {
+            return _409Account(item.Name);
+        }
+
+        account.UpdateFrom(item);
+        _db.Entry(account).State = EntityState.Modified;
+        await _db.SaveChangesAsync();
+        return NoContent();
+    }
+
+    // DELETE: api/accounts/{id}
+    [HttpDelete("{id}")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden, Type = typeof(ErrMessage))]
+    [ProducesResponseType(StatusCodes.Status404NotFound, Type = typeof(ErrMessage))]
+    public async Task<IActionResult> DeleteAccount(int id)
+    {
+        var user = await CurrentUser();
+        if (user == null || !user.IsAdministrator()) return _403();
+
+        var account = await _db.Accounts
+            .Include(a => a.Devices)
+            .Include(a => a.DeviceGroups)
+            .Include(a => a.Videos)
+            .Include(a => a.Playlists)
+            .Include(a => a.Subscriptions)
+            .Include(a => a.UserAccounts)
+            .FirstOrDefaultAsync(a => a.Id == id);
+        if (account == null) return _404Account(id);
+
+        foreach (var device in account.Devices)
+        {
+            device.AccountId = null;
+            device.DeviceGroupId = null;
+        }
+
+        _db.DeviceGroups.RemoveRange(account.DeviceGroups);
+        _db.Videos.RemoveRange(account.Videos);
+        _db.Playlists.RemoveRange(account.Playlists);
+        _db.Subscriptions.RemoveRange(account.Subscriptions);
+        _db.UserAccounts.RemoveRange(account.UserAccounts);
+
+        _db.Accounts.Remove(account);
+        await _db.SaveChangesAsync();
+        return NoContent();
+    }
+}
+

--- a/MediaPi.Core/Controllers/MediaPiControllerBase.cs
+++ b/MediaPi.Core/Controllers/MediaPiControllerBase.cs
@@ -100,6 +100,12 @@ public class FuelfluxControllerPreBase(AppDbContext db, ILogger logger) : Contro
                           new ErrMessage { Msg = $"Устройство с таким IP адресом уже зарегистрировано [ip = {ip}]" });
     }
 
+    protected ObjectResult _409Account(string name)
+    {
+        return StatusCode(StatusCodes.Status409Conflict,
+                          new ErrMessage { Msg = $"Лицевой счёт с таким именем уже существует [name = {name}]" });
+    }
+
     protected ObjectResult _400Ip(string ip)
     {
         return StatusCode(StatusCodes.Status400BadRequest,

--- a/MediaPi.Core/Data/AppDbContext.cs
+++ b/MediaPi.Core/Data/AppDbContext.cs
@@ -127,9 +127,16 @@ namespace MediaPi.Core.Data
                 .HasForeignKey(pd => pd.StatusId);
 
             modelBuilder.Entity<Device>()
+                .HasOne(d => d.Account)
+                .WithMany(a => a.Devices)
+                .HasForeignKey(d => d.AccountId)
+                .OnDelete(DeleteBehavior.SetNull);
+
+            modelBuilder.Entity<Device>()
                 .HasOne(d => d.DeviceGroup)
                 .WithMany(g => g.Devices)
-                .HasForeignKey(d => d.DeviceGroupId);
+                .HasForeignKey(d => d.DeviceGroupId)
+                .OnDelete(DeleteBehavior.SetNull);
 
             modelBuilder.Entity<Device>()
                 .HasIndex(d => d.IpAddress)

--- a/MediaPi.Core/Extensions/AccountExtensions.cs
+++ b/MediaPi.Core/Extensions/AccountExtensions.cs
@@ -1,0 +1,37 @@
+// MIT License
+//
+// Copyright (c) 2025 Maxim [maxirmx] Samsonov (www.sw.consulting)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using MediaPi.Core.Models;
+using MediaPi.Core.RestModels;
+
+namespace MediaPi.Core.Extensions;
+
+public static class AccountExtensions
+{
+    public static AccountViewItem ToViewItem(this Account account) => new(account);
+
+    public static void UpdateFrom(this Account account, AccountUpdateItem item)
+    {
+        if (item.Name != null) account.Name = item.Name;
+    }
+}
+

--- a/MediaPi.Core/Migrations/20250802181507_DeviceAccountOnDeleteSetNull.Designer.cs
+++ b/MediaPi.Core/Migrations/20250802181507_DeviceAccountOnDeleteSetNull.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using MediaPi.Core.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace MediaPi.Core.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250802181507_DeviceAccountOnDeleteSetNull")]
+    partial class DeviceAccountOnDeleteSetNull
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/MediaPi.Core/Migrations/20250802181507_DeviceAccountOnDeleteSetNull.cs
+++ b/MediaPi.Core/Migrations/20250802181507_DeviceAccountOnDeleteSetNull.cs
@@ -1,0 +1,64 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace MediaPi.Core.Migrations
+{
+    /// <inheritdoc />
+    public partial class DeviceAccountOnDeleteSetNull : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_devices_accounts_account_id",
+                table: "devices");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_devices_device_groups_device_group_id",
+                table: "devices");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_devices_accounts_account_id",
+                table: "devices",
+                column: "account_id",
+                principalTable: "accounts",
+                principalColumn: "id",
+                onDelete: ReferentialAction.SetNull);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_devices_device_groups_device_group_id",
+                table: "devices",
+                column: "device_group_id",
+                principalTable: "device_groups",
+                principalColumn: "id",
+                onDelete: ReferentialAction.SetNull);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_devices_accounts_account_id",
+                table: "devices");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_devices_device_groups_device_group_id",
+                table: "devices");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_devices_accounts_account_id",
+                table: "devices",
+                column: "account_id",
+                principalTable: "accounts",
+                principalColumn: "id");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_devices_device_groups_device_group_id",
+                table: "devices",
+                column: "device_group_id",
+                principalTable: "device_groups",
+                principalColumn: "id");
+        }
+    }
+}

--- a/MediaPi.Core/RestModels/AccountCreateItem.cs
+++ b/MediaPi.Core/RestModels/AccountCreateItem.cs
@@ -1,0 +1,37 @@
+// MIT License
+//
+// Copyright (c) 2025 Maxim [maxirmx] Samsonov (www.sw.consulting)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System.Text.Json;
+using MediaPi.Core.Settings;
+
+namespace MediaPi.Core.RestModels;
+
+public class AccountCreateItem
+{
+    public string Name { get; set; } = string.Empty;
+
+    public override string ToString()
+    {
+        return JsonSerializer.Serialize(this, JOptions.DefaultOptions);
+    }
+}
+

--- a/MediaPi.Core/RestModels/AccountUpdateItem.cs
+++ b/MediaPi.Core/RestModels/AccountUpdateItem.cs
@@ -1,0 +1,37 @@
+// MIT License
+//
+// Copyright (c) 2025 Maxim [maxirmx] Samsonov (www.sw.consulting)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System.Text.Json;
+using MediaPi.Core.Settings;
+
+namespace MediaPi.Core.RestModels;
+
+public class AccountUpdateItem
+{
+    public string? Name { get; set; }
+
+    public override string ToString()
+    {
+        return JsonSerializer.Serialize(this, JOptions.DefaultOptions);
+    }
+}
+

--- a/MediaPi.Core/RestModels/AccountViewItem.cs
+++ b/MediaPi.Core/RestModels/AccountViewItem.cs
@@ -1,0 +1,39 @@
+// MIT License
+//
+// Copyright (c) 2025 Maxim [maxirmx] Samsonov (www.sw.consulting)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System.Text.Json;
+using MediaPi.Core.Models;
+using MediaPi.Core.Settings;
+
+namespace MediaPi.Core.RestModels;
+
+public class AccountViewItem(Account account)
+{
+    public int Id { get; set; } = account.Id;
+    public string Name { get; set; } = account.Name;
+
+    public override string ToString()
+    {
+        return JsonSerializer.Serialize(this, JOptions.DefaultOptions);
+    }
+}
+


### PR DESCRIPTION
## Summary
- add AccountsController with CRUD endpoints and role-based access
- ensure deleting accounts clears device references and cascades owned entities
- configure database to set device account and group to null on account removal
- cover account flows with unit tests

## Testing
- `dotnet test MediaPi.sln`

------
https://chatgpt.com/codex/tasks/task_e_688e5478e2588321998951618743c7ae