### PR TITLE
feat: add device status streaming

### DIFF
--- a/MediaPi.Core/Services/DeviceMonitoringService.cs
+++ b/MediaPi.Core/Services/DeviceMonitoringService.cs
@@ -66,11 +66,18 @@ public class DeviceMonitoringService : BackgroundService, IDeviceMonitoringServi
         var channel = Channel.CreateUnbounded<DeviceStatusEvent>();
         var id = Guid.NewGuid();
         _subscribers[id] = channel;
+
+        foreach (var kvp in _snapshot)
+        {
+            channel.Writer.TryWrite(new DeviceStatusEvent(kvp.Key, kvp.Value));
+        }
+
         token.Register(() =>
         {
             _subscribers.TryRemove(id, out _);
             channel.Writer.TryComplete();
         });
+
         return channel.Reader.ReadAllAsync(token);
     }
 

--- a/MediaPi.Core/Services/Models/DeviceStatusEvent.cs
+++ b/MediaPi.Core/Services/Models/DeviceStatusEvent.cs
@@ -20,17 +20,7 @@
 //
 // This file is a part of Media Pi backend application
 
-using MediaPi.Core.Services.Models;
-using System.Collections.Generic;
-using System.Threading;
-using System.Threading.Tasks;
+namespace MediaPi.Core.Services.Models;
 
-namespace MediaPi.Core.Services;
+public record DeviceStatusEvent(int DeviceId, DeviceStatusSnapshot Snapshot);
 
-public interface IDeviceMonitoringService
-{
-    IReadOnlyDictionary<int, DeviceStatusSnapshot> Snapshot { get; }
-    bool TryGetStatus(int deviceId, out DeviceStatusSnapshot status);
-    Task<DeviceStatusSnapshot?> Test(int deviceId, CancellationToken token = default);
-    IAsyncEnumerable<DeviceStatusEvent> Subscribe(CancellationToken token = default);
-}


### PR DESCRIPTION
## Summary
- add DeviceStatusEvent model and expose Subscribe stream from DeviceMonitoringService
- broadcast status updates and expose SSE stream endpoint
- cover streaming with new unit test

## Testing
- `dotnet test MediaPi.sln`

------
https://chatgpt.com/codex/tasks/task_e_68aeeb3ec56483219a783d07cf9bc69d