### PR TITLE
Expose device status via DevicesController

### DIFF
--- a/MediaPi.Core.Tests/Controllers/DevicesControllerErrorTests.cs
+++ b/MediaPi.Core.Tests/Controllers/DevicesControllerErrorTests.cs
@@ -60,6 +60,7 @@ public class DevicesControllerErrorTests
     private DeviceGroup _group2;
     private UserInformationService _userInformationService;
     private DeviceEventsService _deviceEventsService;
+    private Mock<IDeviceMonitoringService> _monitoringServiceMock;
 #pragma warning restore CS8618
 
     [SetUp]
@@ -71,6 +72,7 @@ public class DevicesControllerErrorTests
 
         _dbContext = new AppDbContext(options);
         _deviceEventsService = new DeviceEventsService();
+        _monitoringServiceMock = new Mock<IDeviceMonitoringService>();
 
         _adminRole = new Role { Id = (int)UserRoleConstants.SystemAdministrator, RoleId = UserRoleConstants.SystemAdministrator, Name = "Admin" };
         _managerRole = new Role { Id = (int)UserRoleConstants.AccountManager, RoleId = UserRoleConstants.AccountManager, Name = "Manager" };
@@ -140,7 +142,8 @@ public class DevicesControllerErrorTests
             _userInformationService,
             _dbContext,
             _mockLogger.Object,
-            _deviceEventsService
+            _deviceEventsService,
+            _monitoringServiceMock.Object
         )
         {
             ControllerContext = new ControllerContext { HttpContext = context }

--- a/MediaPi.Core.Tests/Controllers/DevicesControllerTests.cs
+++ b/MediaPi.Core.Tests/Controllers/DevicesControllerTests.cs
@@ -442,7 +442,8 @@ public class DevicesControllerTests
             ConnectLatencyMs = 1,
             TotalLatencyMs = 2
         };
-        _monitoringServiceMock.Setup(s => s.TryGetStatus(1, out snapshot)).Returns(true);
+        _monitoringServiceMock.Setup(s => s.TryGetStatus(1, out It.Ref<DeviceStatusSnapshot>.IsAny))
+            .Returns((int id, out DeviceStatusSnapshot status) => { status = snapshot; return true; });
 
         SetCurrentUser(1);
         var result = await _controller.GetDevice(1);

--- a/MediaPi.Core.Tests/Controllers/DevicesControllerTests.cs
+++ b/MediaPi.Core.Tests/Controllers/DevicesControllerTests.cs
@@ -248,7 +248,8 @@ public class DevicesControllerTests
             ConnectLatencyMs = 1,
             TotalLatencyMs = 2
         };
-        _monitoringServiceMock.Setup(s => s.TryGetStatus(1, out snapshot)).Returns(true);
+        _monitoringServiceMock.Setup(s => s.TryGetStatus(1, out It.Ref<DeviceStatusSnapshot>.IsAny))
+            .Returns((int id, out DeviceStatusSnapshot status) => { status = snapshot; return true; });
 
         SetCurrentUser(1);
         var result = await _controller.GetAll();

--- a/MediaPi.Core.Tests/Controllers/DevicesControllerTests.cs
+++ b/MediaPi.Core.Tests/Controllers/DevicesControllerTests.cs
@@ -28,6 +28,7 @@ using Microsoft.Extensions.Logging;
 using Moq;
 using NUnit.Framework;
 
+using System;
 using System.Linq;
 using System.Net;
 using System.Threading.Tasks;
@@ -37,6 +38,7 @@ using MediaPi.Core.Data;
 using MediaPi.Core.Models;
 using MediaPi.Core.RestModels;
 using MediaPi.Core.Services;
+using MediaPi.Core.Services.Models;
 
 namespace MediaPi.Core.Tests.Controllers;
 
@@ -60,6 +62,7 @@ public class DevicesControllerTests
     private DeviceGroup _group2;
     private UserInformationService _userInformationService;
     private DeviceEventsService _deviceEventsService;
+    private Mock<IDeviceMonitoringService> _monitoringServiceMock;
 #pragma warning restore CS8618
 
     [SetUp]
@@ -71,6 +74,7 @@ public class DevicesControllerTests
 
         _dbContext = new AppDbContext(options);
         _deviceEventsService = new DeviceEventsService();
+        _monitoringServiceMock = new Mock<IDeviceMonitoringService>();
 
         _adminRole = new Role { RoleId = UserRoleConstants.SystemAdministrator, Name = "Admin" };
         _managerRole = new Role { RoleId = UserRoleConstants.AccountManager, Name = "Manager" };
@@ -136,7 +140,8 @@ public class DevicesControllerTests
             _userInformationService,
             _dbContext,
             _mockLogger.Object,
-            _deviceEventsService
+            _deviceEventsService,
+            _monitoringServiceMock.Object
         )
         {
             ControllerContext = new ControllerContext { HttpContext = context }
@@ -230,6 +235,26 @@ public class DevicesControllerTests
         var list = result.Value!.ToList();
         Assert.That(list, Has.Count.EqualTo(1));
         Assert.That(list[0].Id, Is.EqualTo(2));
+    }
+
+    [Test]
+    public async Task GetAll_IncludesDeviceStatus()
+    {
+        var snapshot = new DeviceStatusSnapshot
+        {
+            IpAddress = "1.1.1.1",
+            IsOnline = true,
+            LastChecked = DateTime.UtcNow,
+            ConnectLatencyMs = 1,
+            TotalLatencyMs = 2
+        };
+        _monitoringServiceMock.Setup(s => s.TryGetStatus(1, out snapshot)).Returns(true);
+
+        SetCurrentUser(1);
+        var result = await _controller.GetAll();
+        var item = result.Value!.First(d => d.Id == 1);
+        Assert.That(item.DeviceStatus, Is.Not.Null);
+        Assert.That(item.DeviceStatus!.IsOnline, Is.True);
     }
 
     [Test]
@@ -403,6 +428,26 @@ public class DevicesControllerTests
         Assert.That(result.Result, Is.TypeOf<ObjectResult>());
         var obj = result.Result as ObjectResult;
         Assert.That(obj!.StatusCode, Is.EqualTo(StatusCodes.Status403Forbidden));
+    }
+
+    [Test]
+    public async Task GetDevice_ReturnsDeviceStatus_WhenAvailable()
+    {
+        var snapshot = new DeviceStatusSnapshot
+        {
+            IpAddress = "1.1.1.1",
+            IsOnline = true,
+            LastChecked = DateTime.UtcNow,
+            ConnectLatencyMs = 1,
+            TotalLatencyMs = 2
+        };
+        _monitoringServiceMock.Setup(s => s.TryGetStatus(1, out snapshot)).Returns(true);
+
+        SetCurrentUser(1);
+        var result = await _controller.GetDevice(1);
+        Assert.That(result.Value, Is.Not.Null);
+        Assert.That(result.Value!.DeviceStatus, Is.Not.Null);
+        Assert.That(result.Value!.DeviceStatus!.IsOnline, Is.True);
     }
 
     [Test]

--- a/MediaPi.Core/Controllers/DevicesController.cs
+++ b/MediaPi.Core/Controllers/DevicesController.cs
@@ -42,7 +42,8 @@ public class DevicesController(
     IUserInformationService userInformationService,
     AppDbContext db,
     ILogger<DevicesController> logger,
-    DeviceEventsService deviceEventsService) : MediaPiControllerBase(httpContextAccessor, db, logger)
+    DeviceEventsService deviceEventsService,
+    IDeviceMonitoringService monitoringService) : MediaPiControllerBase(httpContextAccessor, db, logger)
 {
     // POST: api/devices/register
     [AllowAnonymous]
@@ -101,7 +102,11 @@ public class DevicesController(
         }
 
         var devices = await query.ToListAsync();
-        return devices.Select(d => d.ToViewItem()).ToList();
+        return devices.Select(d =>
+        {
+            monitoringService.TryGetStatus(d.Id, out var status);
+            return d.ToViewItem(status);
+        }).ToList();
     }
 
     // GET: api/devices/by-account/{accountId?}
@@ -139,7 +144,11 @@ public class DevicesController(
         }
 
         var devices = await query.ToListAsync();
-        return devices.Select(d => d.ToViewItem()).ToList();
+        return devices.Select(d =>
+        {
+            monitoringService.TryGetStatus(d.Id, out var status);
+            return d.ToViewItem(status);
+        }).ToList();
     }
 
     // GET: api/devices/by-device-group/{deviceGroupId?}
@@ -190,7 +199,11 @@ public class DevicesController(
         }
 
         var devices = await query.ToListAsync();
-        return devices.Select(d => d.ToViewItem()).ToList();
+        return devices.Select(d =>
+        {
+            monitoringService.TryGetStatus(d.Id, out var status);
+            return d.ToViewItem(status);
+        }).ToList();
     }
 
     // GET: api/devices/5
@@ -209,7 +222,8 @@ public class DevicesController(
         if (user.IsAdministrator() || userInformationService.ManagerOwnsDevice(user, device) ||
             (user.IsEngineer() && device.AccountId == null))
         {
-            return device.ToViewItem();
+            monitoringService.TryGetStatus(device.Id, out var status);
+            return device.ToViewItem(status);
         }
 
         return _403();

--- a/MediaPi.Core/Extensions/DeviceExtensions.cs
+++ b/MediaPi.Core/Extensions/DeviceExtensions.cs
@@ -22,12 +22,13 @@
 
 using MediaPi.Core.Models;
 using MediaPi.Core.RestModels;
+using MediaPi.Core.Services.Models;
 
 namespace MediaPi.Core.Extensions;
 
 public static class DeviceExtensions
 {
-    public static DeviceViewItem ToViewItem(this Device device) => new(device);
+    public static DeviceViewItem ToViewItem(this Device device, DeviceStatusSnapshot? status = null) => new(device, status);
 
     public static void UpdateFrom(this Device device, DeviceUpdateItem item)
     {

--- a/MediaPi.Core/RestModels/DeviceViewItem.cs
+++ b/MediaPi.Core/RestModels/DeviceViewItem.cs
@@ -24,16 +24,18 @@ using System.Text.Json;
 
 using MediaPi.Core.Models;
 using MediaPi.Core.Settings;
+using MediaPi.Core.Services.Models;
 
 namespace MediaPi.Core.RestModels;
 
-public class DeviceViewItem(Device device)
+public class DeviceViewItem(Device device, DeviceStatusSnapshot? status = null)
 {
     public int Id { get; set; } = device.Id;
     public string Name { get; set; } = device.Name;
     public string IpAddress { get; set; } = device.IpAddress;
     public int? AccountId { get; set; } = device.AccountId;
     public int? DeviceGroupId { get; set; } = device.DeviceGroupId;
+    public DeviceStatusSnapshot? DeviceStatus { get; set; } = status;
 
     public override string ToString()
     {


### PR DESCRIPTION
## Summary
- include `DeviceStatus` in `DeviceViewItem`
- propagate device status snapshots from `IDeviceMonitoringService` through `DevicesController`
- add tests covering device status in controller responses

## Testing
- `dotnet test MediaPi.sln --collect:"XPlat Code Coverage"`


------
https://chatgpt.com/codex/tasks/task_e_68b00f4b3734832182f3db58f6971a65