### PR TITLE
fix: guard device polling and add probe timeout

### DIFF
--- a/MediaPi.Core.Tests/Controllers/DeviceStatusesControllerTests.cs
+++ b/MediaPi.Core.Tests/Controllers/DeviceStatusesControllerTests.cs
@@ -102,6 +102,7 @@ public class DeviceStatusesControllerTests
         }
     }
 
+    [Test]
     public async Task Get_ReturnsNotFound_WhenDeviceMissing()
     {
         _monitoringServiceMock.Setup(s => s.Test(99, It.IsAny<CancellationToken>())).ReturnsAsync((DeviceStatusSnapshot?)null);

--- a/MediaPi.Core.Tests/Services/DeviceMonitoringServiceTests.cs
+++ b/MediaPi.Core.Tests/Services/DeviceMonitoringServiceTests.cs
@@ -162,6 +162,39 @@ public class DeviceMonitoringServiceTests
     }
 
     [Test]
+    public async Task ExecuteAsync_Continues_WhenDeviceRemovedFromDatabase()
+    {
+        var device = new Device { Id = 6, IpAddress = "127.0.0.1", Name = "TestDevice6" };
+        var db = CreateDbContext(device);
+        var logs = new List<string>();
+        var eventsService = CreateDeviceEventsService();
+        var service = new DeviceMonitoringService(
+            CreateScopeFactory(db),
+            Options.Create(GetDefaultSettings()),
+            CreateLogger(logs),
+            eventsService);
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(4));
+        var task = service.StartAsync(cts.Token);
+
+        await Task.Delay(1500);
+        db.Devices.Remove(device);
+        await db.SaveChangesAsync();
+        eventsService.OnDeviceDeleted(device.Id);
+
+        await Task.Delay(1000);
+        cts.Cancel();
+        await task;
+
+        bool hasFatal;
+        lock (logs)
+        {
+            hasFatal = logs.Any(l => l.Contains("fatal error"));
+        }
+        Assert.That(hasFatal, Is.False);
+    }
+
+    [Test]
     public async Task Probe_ReturnsFalse_ForInvalidIp()
     {
         var db = CreateDbContext();


### PR DESCRIPTION
## Summary
- avoid exceptions by removing stale device IDs when building monitoring queue
- enforce per-probe read timeout in monitoring service
- cover missing controller path and add regression test for deleted devices

## Testing
- `dotnet test MediaPi.sln`

------
https://chatgpt.com/codex/tasks/task_e_68b1bffa72b88321a684e9b9ffa5e773