### PR TITLE
Add SSH media agent client

### DIFF
--- a/MediaPi.Core.Tests/Utils/MediaPiAgentClientTests.cs
+++ b/MediaPi.Core.Tests/Utils/MediaPiAgentClientTests.cs
@@ -1,0 +1,203 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using MediaPi.Core.Models;
+using MediaPi.Core.Utils;
+using NUnit.Framework;
+
+namespace MediaPi.Core.Tests.Utils;
+
+public class MediaPiAgentClientTests
+{
+    [Test]
+    public async Task ListUnitsAsync_ReturnsUnits()
+    {
+        var responses = new Dictionary<string, string>
+        {
+            ["media-pi-agent list"] = "{\"ok\":true,\"units\":[\"mpd.service\",\"kiosk.service\"]}\n",
+        };
+
+        var factory = new FakeSessionFactory(command => responses.TryGetValue(command, out var value)
+            ? value
+            : throw new InvalidOperationException($"Unexpected command: {command}"));
+        var client = new MediaPiAgentClient(factory);
+
+        var result = await client.ListUnitsAsync(CreateDevice());
+
+        Assert.That(result.Ok, Is.True);
+        Assert.That(result.Units, Is.EqualTo(new[] { "mpd.service", "kiosk.service" }));
+        Assert.That(factory.Commands, Is.EqualTo(new[] { "media-pi-agent list" }));
+    }
+
+    [Test]
+    public async Task GetStatusAsync_ReturnsStatusDetails()
+    {
+        var responses = new Dictionary<string, string>
+        {
+            ["media-pi-agent status \"mpd.service\""] = "{\"ok\":true,\"unit\":\"mpd.service\",\"active\":\"active\",\"sub\":\"running\"}",
+        };
+
+        var factory = new FakeSessionFactory(command => responses.TryGetValue(command, out var value)
+            ? value
+            : throw new InvalidOperationException($"Unexpected command: {command}"));
+        var client = new MediaPiAgentClient(factory);
+
+        var result = await client.GetStatusAsync(CreateDevice(), "mpd.service");
+
+        Assert.That(result.Ok, Is.True);
+        Assert.That(result.Active, Is.EqualTo("active"));
+        Assert.That(result.Sub, Is.EqualTo("running"));
+        Assert.That(factory.Commands, Is.EqualTo(new[] { "media-pi-agent status \"mpd.service\"" }));
+    }
+
+    [Test]
+    public async Task StartUnitAsync_QuotesUnitName()
+    {
+        var responses = new Dictionary<string, string>
+        {
+            ["media-pi-agent start \"mpd@foo.service\""] = "{\"ok\":true,\"unit\":\"mpd@foo.service\",\"result\":\"done\"}",
+        };
+
+        var factory = new FakeSessionFactory(command => responses.TryGetValue(command, out var value)
+            ? value
+            : throw new InvalidOperationException($"Unexpected command: {command}"));
+        var client = new MediaPiAgentClient(factory);
+
+        var response = await client.StartUnitAsync(CreateDevice(), "mpd@foo.service");
+
+        Assert.That(response.Ok, Is.True);
+        Assert.That(response.Unit, Is.EqualTo("mpd@foo.service"));
+        Assert.That(response.Result, Is.EqualTo("done"));
+        Assert.That(factory.Commands, Is.EqualTo(new[] { "media-pi-agent start \"mpd@foo.service\"" }));
+    }
+
+    [Test]
+    public async Task GetStatusAsync_ReturnsErrorInformation()
+    {
+        var responses = new Dictionary<string, string>
+        {
+            ["media-pi-agent status \"forbidden.service\""] = "{\"ok\":false,\"error\":\"unit forbidden\"}",
+        };
+
+        var factory = new FakeSessionFactory(command => responses.TryGetValue(command, out var value)
+            ? value
+            : throw new InvalidOperationException($"Unexpected command: {command}"));
+        var client = new MediaPiAgentClient(factory);
+
+        var response = await client.GetStatusAsync(CreateDevice(), "forbidden.service");
+
+        Assert.That(response.Ok, Is.False);
+        Assert.That(response.Error, Is.EqualTo("unit forbidden"));
+    }
+
+    [Test]
+    public async Task EnableUnitAsync_ReturnsEnabledState()
+    {
+        var responses = new Dictionary<string, string>
+        {
+            ["media-pi-agent enable \"mpd.service\""] = "{\"ok\":true,\"unit\":\"mpd.service\",\"enabled\":true}",
+        };
+
+        var factory = new FakeSessionFactory(command => responses.TryGetValue(command, out var value)
+            ? value
+            : throw new InvalidOperationException($"Unexpected command: {command}"));
+        var client = new MediaPiAgentClient(factory);
+
+        var response = await client.EnableUnitAsync(CreateDevice(), "mpd.service");
+
+        Assert.That(response.Ok, Is.True);
+        Assert.That(response.Enabled, Is.True);
+    }
+
+    [Test]
+    public void GetStatusAsync_WithEmptyUnit_Throws()
+    {
+        var factory = new FakeSessionFactory(_ => throw new InvalidOperationException("Should not execute"));
+        var client = new MediaPiAgentClient(factory);
+
+        Assert.ThrowsAsync<ArgumentException>(() => client.GetStatusAsync(CreateDevice(), ""));
+    }
+
+    [Test]
+    public async Task GetStatusAsync_TrimsUnitBeforeSending()
+    {
+        var responses = new Dictionary<string, string>
+        {
+            ["media-pi-agent status \"mpd.service\""] = "{\"ok\":true,\"unit\":\"mpd.service\",\"active\":\"active\",\"sub\":\"running\"}",
+        };
+
+        var factory = new FakeSessionFactory(command => responses.TryGetValue(command, out var value)
+            ? value
+            : throw new InvalidOperationException($"Unexpected command: {command}"));
+        var client = new MediaPiAgentClient(factory);
+
+        await client.GetStatusAsync(CreateDevice(), "  mpd.service  ");
+
+        Assert.That(factory.Commands, Is.EqualTo(new[] { "media-pi-agent status \"mpd.service\"" }));
+    }
+
+    private static Device CreateDevice() => new()
+    {
+        Id = 1,
+        Name = "Device 1",
+        IpAddress = "127.0.0.1",
+        PublicKeyOpenSsh = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDdummy",
+        SshUser = "pi",
+    };
+
+    private sealed class FakeSessionFactory : ISshSessionFactory
+    {
+        private readonly Func<string, string> _responseFactory;
+
+        public FakeSessionFactory(Func<string, string> responseFactory)
+        {
+            _responseFactory = responseFactory;
+        }
+
+        public IList<string> Commands { get; } = new List<string>();
+
+        public Task<ISshSession> CreateAsync(Device device, CancellationToken cancellationToken) =>
+            Task.FromResult<ISshSession>(new FakeSession(_responseFactory, Commands));
+
+        private sealed class FakeSession : ISshSession
+        {
+            private readonly Func<string, string> _responseFactory;
+            private readonly IList<string> _commands;
+
+            public FakeSession(Func<string, string> responseFactory, IList<string> commands)
+            {
+                _responseFactory = responseFactory;
+                _commands = commands;
+            }
+
+            public Task<string> ExecuteAsync(string command, CancellationToken cancellationToken)
+            {
+                _commands.Add(command);
+                return Task.FromResult(_responseFactory(command));
+            }
+
+            public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+        }
+    }
+}
+
+public class SshNetSessionFactoryTests
+{
+    [Test]
+    public void CreateAsync_MissingPublicKey_Throws()
+    {
+        var device = new Device
+        {
+            Id = 1,
+            Name = "Device",
+            IpAddress = "127.0.0.1",
+            PublicKeyOpenSsh = string.Empty,
+            SshUser = "pi",
+        };
+
+        var factory = new SshNetSessionFactory();
+
+        Assert.ThrowsAsync<InvalidOperationException>(() => factory.CreateAsync(device, CancellationToken.None));
+    }
+}

--- a/MediaPi.Core/MediaPi.Core.csproj
+++ b/MediaPi.Core/MediaPi.Core.csproj
@@ -23,6 +23,7 @@
     <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="8.14.0" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.22.1" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.0.4" />
+    <PackageReference Include="Renci.SshNet.Async" Version="1.4.0" />
     <PackageReference Include="SharpCompress" Version="0.40.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="9.0.3" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.14.0" />

--- a/MediaPi.Core/Utils/MediaPiAgentClient.cs
+++ b/MediaPi.Core/Utils/MediaPiAgentClient.cs
@@ -1,0 +1,270 @@
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Threading.Tasks;
+using MediaPi.Core.Models;
+using Renci.SshNet;
+using Renci.SshNet.Async;
+using SshConnectionInfo = Renci.SshNet.ConnectionInfo;
+
+namespace MediaPi.Core.Utils;
+
+public interface IMediaPiAgentClient
+{
+    Task<MediaPiAgentListResponse> ListUnitsAsync(Device device, CancellationToken cancellationToken = default);
+
+    Task<MediaPiAgentStatusResponse> GetStatusAsync(Device device, string unit, CancellationToken cancellationToken = default);
+
+    Task<MediaPiAgentUnitResultResponse> StartUnitAsync(Device device, string unit, CancellationToken cancellationToken = default);
+
+    Task<MediaPiAgentUnitResultResponse> StopUnitAsync(Device device, string unit, CancellationToken cancellationToken = default);
+
+    Task<MediaPiAgentUnitResultResponse> RestartUnitAsync(Device device, string unit, CancellationToken cancellationToken = default);
+
+    Task<MediaPiAgentEnableResponse> EnableUnitAsync(Device device, string unit, CancellationToken cancellationToken = default);
+
+    Task<MediaPiAgentEnableResponse> DisableUnitAsync(Device device, string unit, CancellationToken cancellationToken = default);
+}
+
+public sealed class MediaPiAgentClient : IMediaPiAgentClient
+{
+    private const string AgentExecutable = "media-pi-agent";
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true,
+    };
+
+    private readonly ISshSessionFactory _sessionFactory;
+
+    public MediaPiAgentClient()
+        : this(new SshNetSessionFactory())
+    {
+    }
+
+    public MediaPiAgentClient(ISshSessionFactory sessionFactory)
+    {
+        _sessionFactory = sessionFactory ?? throw new ArgumentNullException(nameof(sessionFactory));
+    }
+
+    public Task<MediaPiAgentListResponse> ListUnitsAsync(Device device, CancellationToken cancellationToken = default) =>
+        ExecuteAsync<MediaPiAgentListResponse>(device, cancellationToken, "list");
+
+    public Task<MediaPiAgentStatusResponse> GetStatusAsync(Device device, string unit, CancellationToken cancellationToken = default) =>
+        ExecuteAsync<MediaPiAgentStatusResponse>(device, cancellationToken, "status", EnsureUnit(unit));
+
+    public Task<MediaPiAgentUnitResultResponse> StartUnitAsync(Device device, string unit, CancellationToken cancellationToken = default) =>
+        ExecuteAsync<MediaPiAgentUnitResultResponse>(device, cancellationToken, "start", EnsureUnit(unit));
+
+    public Task<MediaPiAgentUnitResultResponse> StopUnitAsync(Device device, string unit, CancellationToken cancellationToken = default) =>
+        ExecuteAsync<MediaPiAgentUnitResultResponse>(device, cancellationToken, "stop", EnsureUnit(unit));
+
+    public Task<MediaPiAgentUnitResultResponse> RestartUnitAsync(Device device, string unit, CancellationToken cancellationToken = default) =>
+        ExecuteAsync<MediaPiAgentUnitResultResponse>(device, cancellationToken, "restart", EnsureUnit(unit));
+
+    public Task<MediaPiAgentEnableResponse> EnableUnitAsync(Device device, string unit, CancellationToken cancellationToken = default) =>
+        ExecuteAsync<MediaPiAgentEnableResponse>(device, cancellationToken, "enable", EnsureUnit(unit));
+
+    public Task<MediaPiAgentEnableResponse> DisableUnitAsync(Device device, string unit, CancellationToken cancellationToken = default) =>
+        ExecuteAsync<MediaPiAgentEnableResponse>(device, cancellationToken, "disable", EnsureUnit(unit));
+
+    private async Task<TResponse> ExecuteAsync<TResponse>(Device device, CancellationToken cancellationToken, string command, params string[] args)
+    {
+        if (device is null) throw new ArgumentNullException(nameof(device));
+        if (string.IsNullOrWhiteSpace(command)) throw new ArgumentException("Command must be provided.", nameof(command));
+
+        var commandText = BuildCommand(command, args);
+
+        await using var session = await _sessionFactory.CreateAsync(device, cancellationToken).ConfigureAwait(false);
+        var rawOutput = await session.ExecuteAsync(commandText, cancellationToken).ConfigureAwait(false);
+        if (string.IsNullOrWhiteSpace(rawOutput))
+        {
+            throw new InvalidOperationException($"SSH command '{commandText}' returned no output.");
+        }
+
+        var trimmed = rawOutput.Trim();
+        try
+        {
+            return JsonSerializer.Deserialize<TResponse>(trimmed, JsonOptions)
+                   ?? throw new InvalidOperationException($"Unable to deserialize response for command '{command}'.");
+        }
+        catch (JsonException ex)
+        {
+            throw new InvalidOperationException($"Failed to parse JSON response from '{command}' command.", ex);
+        }
+    }
+
+    private static string EnsureUnit(string unit)
+    {
+        if (string.IsNullOrWhiteSpace(unit))
+        {
+            throw new ArgumentException("Unit name must be provided.", nameof(unit));
+        }
+
+        return unit.Trim();
+    }
+
+    private static string BuildCommand(string command, params string[] args)
+    {
+        var builder = new StringBuilder();
+        builder.Append(AgentExecutable);
+        builder.Append(' ');
+        builder.Append(command);
+
+        if (args is { Length: > 0 })
+        {
+            foreach (var arg in args)
+            {
+                builder.Append(' ');
+                builder.Append(EscapeArgument(arg));
+            }
+        }
+
+        return builder.ToString();
+    }
+
+    private static string EscapeArgument(string value)
+    {
+        var escaped = value.Replace("\"", "\\\"");
+        return $"\"{escaped}\"";
+    }
+}
+
+public interface ISshSessionFactory
+{
+    Task<ISshSession> CreateAsync(Device device, CancellationToken cancellationToken);
+}
+
+public interface ISshSession : IAsyncDisposable
+{
+    Task<string> ExecuteAsync(string command, CancellationToken cancellationToken);
+}
+
+public sealed class SshNetSessionFactory : ISshSessionFactory
+{
+    public async Task<ISshSession> CreateAsync(Device device, CancellationToken cancellationToken)
+    {
+        if (device is null) throw new ArgumentNullException(nameof(device));
+        if (string.IsNullOrWhiteSpace(device.IpAddress))
+        {
+            throw new ArgumentException("Device IP address must be provided.", nameof(device));
+        }
+
+        var user = string.IsNullOrWhiteSpace(device.SshUser) ? "pi" : device.SshUser.Trim();
+        if (string.IsNullOrWhiteSpace(user))
+        {
+            throw new InvalidOperationException("SSH user name is missing.");
+        }
+
+        if (string.IsNullOrWhiteSpace(device.PublicKeyOpenSsh))
+        {
+            throw new InvalidOperationException("Device SSH key is missing.");
+        }
+
+        PrivateKeyFile privateKeyFile;
+        try
+        {
+            privateKeyFile = new PrivateKeyFile(new MemoryStream(Encoding.UTF8.GetBytes(device.PublicKeyOpenSsh)));
+        }
+        catch (Exception ex)
+        {
+            throw new InvalidOperationException("Device SSH key is invalid.", ex);
+        }
+
+        var authentication = new PrivateKeyAuthenticationMethod(user, privateKeyFile);
+        var connectionInfo = new SshConnectionInfo(device.IpAddress, user, authentication);
+        var client = new SshClient(connectionInfo);
+
+        try
+        {
+            await Task.Run(() => client.Connect(), cancellationToken).ConfigureAwait(false);
+            return new SshNetSession(client, privateKeyFile);
+        }
+        catch
+        {
+            client.Dispose();
+            privateKeyFile.Dispose();
+            throw;
+        }
+    }
+}
+
+internal sealed class SshNetSession : ISshSession
+{
+    private readonly SshClient _client;
+    private readonly PrivateKeyFile _privateKeyFile;
+
+    public SshNetSession(SshClient client, PrivateKeyFile privateKeyFile)
+    {
+        _client = client;
+        _privateKeyFile = privateKeyFile;
+    }
+
+    public async Task<string> ExecuteAsync(string command, CancellationToken cancellationToken)
+    {
+        using var sshCommand = _client.CreateCommand(command);
+        var factory = new TaskFactory<string>(cancellationToken, TaskCreationOptions.None, TaskContinuationOptions.None, TaskScheduler.Default);
+        var output = await sshCommand.ExecuteAsync(factory).ConfigureAwait(false);
+        if (string.IsNullOrEmpty(output))
+        {
+            output = sshCommand.Error;
+        }
+        if (string.IsNullOrWhiteSpace(output))
+        {
+            throw new InvalidOperationException($"SSH command '{command}' returned no output.");
+        }
+
+        return output;
+    }
+
+    public ValueTask DisposeAsync()
+    {
+        _client.Dispose();
+        _privateKeyFile.Dispose();
+        return ValueTask.CompletedTask;
+    }
+}
+
+public record class MediaPiAgentResponse
+{
+    [JsonPropertyName("ok")]
+    public bool Ok { get; init; }
+
+    [JsonPropertyName("error")]
+    public string? Error { get; init; }
+}
+
+public record class MediaPiAgentListResponse : MediaPiAgentResponse
+{
+    [JsonPropertyName("units")]
+    public IReadOnlyList<string> Units { get; init; } = Array.Empty<string>();
+}
+
+public record class MediaPiAgentStatusResponse : MediaPiAgentResponse
+{
+    [JsonPropertyName("unit")]
+    public string? Unit { get; init; }
+
+    [JsonPropertyName("active")]
+    public string? Active { get; init; }
+
+    [JsonPropertyName("sub")]
+    public string? Sub { get; init; }
+}
+
+public record class MediaPiAgentUnitResultResponse : MediaPiAgentResponse
+{
+    [JsonPropertyName("unit")]
+    public string? Unit { get; init; }
+
+    [JsonPropertyName("result")]
+    public string? Result { get; init; }
+}
+
+public record class MediaPiAgentEnableResponse : MediaPiAgentResponse
+{
+    [JsonPropertyName("unit")]
+    public string? Unit { get; init; }
+
+    [JsonPropertyName("enabled")]
+    public bool? Enabled { get; init; }
+}


### PR DESCRIPTION
## Summary
- add a MediaPiAgentClient utility that connects to devices via SSH using the stored username and key
- expose typed responses for all media-pi-agent commands and shared SSH session abstractions
- add unit tests covering command invocation, error scenarios, and session factory validation

## Testing
- dotnet test MediaPi.sln

------
https://chatgpt.com/codex/tasks/task_e_68cd7601612883219a89faafa7ae7fca