### PR TITLE
Add device service management endpoints

### DIFF
--- a/MediaPi.Core/Controllers/MediaPiControllerBase.cs
+++ b/MediaPi.Core/Controllers/MediaPiControllerBase.cs
@@ -97,6 +97,21 @@ public class FuelfluxControllerPreBase(AppDbContext db, ILogger logger) : Contro
                           new ErrMessage { Msg = $"Группа устройств [id={deviceGroupId}] не принадлежит к тому же лицевому счёту, что и устройство ({deviceAccountMsg})" });
     }
 
+    protected ObjectResult _400ServiceUnit(string? unit)
+    {
+        var displayValue = string.IsNullOrWhiteSpace(unit) ? "<пусто>" : unit;
+        return StatusCode(StatusCodes.Status400BadRequest,
+                          new ErrMessage { Msg = $"Неверное имя сервиса [{displayValue}]" });
+    }
+
+    protected ObjectResult _502Agent(string? message = null)
+    {
+        const string baseMessage = "Ошибка при обращении к агенту устройства";
+        var finalMessage = string.IsNullOrWhiteSpace(message) ? baseMessage : $"{baseMessage}: {message}";
+        return StatusCode(StatusCodes.Status502BadGateway,
+                          new ErrMessage { Msg = finalMessage });
+    }
+
     protected ObjectResult _500Mapping(string fname)
     {
         return StatusCode(StatusCodes.Status500InternalServerError,


### PR DESCRIPTION
## Summary
- add service management endpoints to DevicesController that delegate to the MediaPi agent client and enforce role-based access
- provide controller base helpers for invalid service names and agent communication errors
- cover the new endpoints with unit tests for success and failure scenarios across roles

## Testing
- dotnet test *(fails: dotnet command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cd9a8e1cd48321ab9cc6b439a58854