### PR TITLE
Generalize storage into FileStorageService and extend VideoStorageService

### DIFF
--- a/MediaPi.Core.Tests/Services/FileStorageServiceTests.cs
+++ b/MediaPi.Core.Tests/Services/FileStorageServiceTests.cs
@@ -130,4 +130,30 @@ public class FileStorageServiceTests
     {
         Assert.Throws<InvalidOperationException>(() => _service.GetAbsolutePath("../../../etc/passwd"));
     }
+
+    [Test]
+    public async Task SaveFileAsync_WithComputeSha256_ReturnsCorrectHash()
+    {
+        var content = "hello world";
+        var mockFile = CreateMockFormFile("image.png", content);
+
+        var result = await _service.SaveFileAsync(mockFile.Object, "Image", computeSha256: true);
+
+        Assert.That(result.Sha256, Is.Not.Null.And.Not.Empty);
+
+        using var sha256 = System.Security.Cryptography.SHA256.Create();
+        var bytes = System.Text.Encoding.UTF8.GetBytes(content);
+        var expectedHash = BitConverter.ToString(sha256.ComputeHash(bytes)).Replace("-", "").ToLowerInvariant();
+        Assert.That(result.Sha256, Is.EqualTo(expectedHash));
+    }
+
+    [Test]
+    public async Task SaveFileAsync_WithoutComputeSha256_ReturnsNullHash()
+    {
+        var mockFile = CreateMockFormFile("image.png", "content");
+
+        var result = await _service.SaveFileAsync(mockFile.Object, "Image");
+
+        Assert.That(result.Sha256, Is.Null);
+    }
 }

--- a/MediaPi.Core.Tests/Services/FileStorageServiceTests.cs
+++ b/MediaPi.Core.Tests/Services/FileStorageServiceTests.cs
@@ -1,0 +1,133 @@
+// Copyright (c) 2025-2026 sw.consulting
+// This file is a part of Media Pi backend
+
+using System;
+using System.Collections.Concurrent;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using MediaPi.Core.Services;
+using MediaPi.Core.Settings;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Options;
+using Moq;
+using NUnit.Framework;
+
+namespace MediaPi.Core.Tests.Services;
+
+[TestFixture]
+public class FileStorageServiceTests
+{
+    private Mock<IOptions<VideoStorageSettings>> _mockOptions = null!;
+    private VideoStorageSettings _settings = null!;
+    private string _testRootPath = null!;
+    private FileStorageService _service = null!;
+    private readonly ConcurrentBag<MemoryStream> _memoryStreams = new();
+
+    [SetUp]
+    public void SetUp()
+    {
+        _testRootPath = Path.Combine(Path.GetTempPath(), $"file_storage_test_{Guid.NewGuid()}");
+        Directory.CreateDirectory(_testRootPath);
+
+        _settings = new VideoStorageSettings
+        {
+            RootPath = _testRootPath,
+            MaxFilesPerDirectory = 2
+        };
+
+        _mockOptions = new Mock<IOptions<VideoStorageSettings>>();
+        _mockOptions.Setup(x => x.Value).Returns(_settings);
+        _service = new FileStorageService(_mockOptions.Object);
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        foreach (var stream in _memoryStreams)
+        {
+            stream.Dispose();
+        }
+        _memoryStreams.Clear();
+
+        if (Directory.Exists(_testRootPath))
+        {
+            Directory.Delete(_testRootPath, true);
+        }
+    }
+
+    private Mock<IFormFile> CreateMockFormFile(string fileName, string content)
+    {
+        var mockFile = new Mock<IFormFile>();
+        var ms = new MemoryStream();
+        _memoryStreams.Add(ms);
+        using (var writer = new StreamWriter(ms, leaveOpen: true))
+        {
+            writer.Write(content);
+            writer.Flush();
+        }
+        ms.Position = 0;
+
+        mockFile.Setup(f => f.FileName).Returns(fileName);
+        mockFile.Setup(f => f.Length).Returns(ms.Length);
+        mockFile.Setup(f => f.CopyToAsync(It.IsAny<Stream>(), It.IsAny<CancellationToken>()))
+            .Returns((Stream stream, CancellationToken token) => ms.CopyToAsync(stream, token));
+
+        return mockFile;
+    }
+
+    [Test]
+    public async Task SaveFileAsync_ValidFile_SavesWithoutVideoMetadata()
+    {
+        var mockFile = CreateMockFormFile("poster.png", "image-content");
+
+        var result = await _service.SaveFileAsync(mockFile.Object, "Poster Image");
+
+        Assert.That(result.OriginalFilename, Is.EqualTo("poster.png"));
+        Assert.That(result.Filename, Does.Contain("poster-image"));
+        Assert.That(result.Filename, Does.EndWith(".png"));
+        var fullPath = _service.GetAbsolutePath(result.Filename);
+        Assert.That(File.Exists(fullPath), Is.True);
+    }
+
+    [Test]
+    public async Task SaveFileAsync_EmptyTitle_UsesFileFallback()
+    {
+        var mockFile = CreateMockFormFile("asset", "abc");
+
+        var result = await _service.SaveFileAsync(mockFile.Object, string.Empty);
+
+        Assert.That(result.Filename, Does.Contain("file"));
+        Assert.That(result.Filename, Does.EndWith(".bin"));
+    }
+
+    [Test]
+    public async Task SaveFileAsync_RespectsMaxFilesPerDirectory()
+    {
+        for (int i = 0; i < _settings.MaxFilesPerDirectory + 1; i++)
+        {
+            var mockFile = CreateMockFormFile($"image{i}.jpg", $"content{i}");
+            await _service.SaveFileAsync(mockFile.Object, $"Image {i}");
+        }
+
+        var directories = Directory.GetDirectories(_testRootPath);
+        Assert.That(directories.Length, Is.EqualTo(2));
+    }
+
+    [Test]
+    public async Task DeleteFileAsync_ExistingFile_DeletesSuccessfully()
+    {
+        var mockFile = CreateMockFormFile("to-delete.png", "content");
+        var result = await _service.SaveFileAsync(mockFile.Object, "Delete me");
+
+        await _service.DeleteFileAsync(result.Filename);
+
+        Assert.That(File.Exists(_service.GetAbsolutePath(result.Filename)), Is.False);
+    }
+
+    [Test]
+    public void GetAbsolutePath_PathTraversal_ThrowsInvalidOperationException()
+    {
+        Assert.Throws<InvalidOperationException>(() => _service.GetAbsolutePath("../../../etc/passwd"));
+    }
+}

--- a/MediaPi.Core/Program.cs
+++ b/MediaPi.Core/Program.cs
@@ -96,6 +96,7 @@ builder.Services.AddSingleton<DeviceMonitoringService>();
 builder.Services.AddSingleton<IDeviceMonitoringService>(sp => sp.GetRequiredService<DeviceMonitoringService>());
 builder.Services.AddHostedService(sp => sp.GetRequiredService<DeviceMonitoringService>());
 builder.Services.AddSingleton<IVideoMetadataService, VideoMetadataService>();
+builder.Services.AddSingleton<IFileStorageService, FileStorageService>();
 builder.Services.AddSingleton<IVideoStorageService, VideoStorageService>();
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen(c =>

--- a/MediaPi.Core/Services/FileStorageService.cs
+++ b/MediaPi.Core/Services/FileStorageService.cs
@@ -104,7 +104,15 @@ public class FileStorageService : IFileStorageService
 
         foreach (var directory in directories)
         {
-            var fileCount = Directory.GetFiles(directory).Length;
+            var fileCount = 0;
+            foreach (var _ in Directory.EnumerateFiles(directory))
+            {
+                fileCount++;
+                if (fileCount >= _settings.MaxFilesPerDirectory)
+                {
+                    break;
+                }
+            }
             if (fileCount < _settings.MaxFilesPerDirectory)
             {
                 return directory;

--- a/MediaPi.Core/Services/FileStorageService.cs
+++ b/MediaPi.Core/Services/FileStorageService.cs
@@ -65,12 +65,11 @@ public class FileStorageService : IFileStorageService
                 Share = FileShare.None,
                 Options = FileOptions.Asynchronous | FileOptions.SequentialScan
             });
-            await using (var cs = new CryptoStream(fs, sha256, CryptoStreamMode.Write, leaveOpen: true))
+            await using (var cs = new CryptoStream(fs, sha256, CryptoStreamMode.Write))
             {
                 await file.CopyToAsync(cs, ct);
                 await cs.FlushFinalBlockAsync(ct);
             }
-            await fs.FlushAsync(ct);
             sha256Hash = BitConverter.ToString(sha256.Hash!).Replace("-", "").ToLowerInvariant();
         }
         else

--- a/MediaPi.Core/Services/FileStorageService.cs
+++ b/MediaPi.Core/Services/FileStorageService.cs
@@ -1,0 +1,156 @@
+// Copyright (c) 2025-2026 sw.consulting
+// This file is a part of Media Pi backend
+
+using System.Globalization;
+using Microsoft.Extensions.Options;
+
+using MediaPi.Core.Services.Interfaces;
+using MediaPi.Core.Settings;
+
+namespace MediaPi.Core.Services;
+
+public class FileStorageService : IFileStorageService
+{
+    private readonly VideoStorageSettings _settings;
+    private readonly string _rootFullPath;
+    private readonly string _rootFullPathWithSeparator;
+
+    public FileStorageService(IOptions<VideoStorageSettings> options)
+    {
+        _settings = options.Value ?? throw new ArgumentNullException(nameof(options));
+
+        if (string.IsNullOrWhiteSpace(_settings.RootPath))
+        {
+            throw new ArgumentException("RootPath must be provided", nameof(options));
+        }
+
+        _rootFullPath = Path.GetFullPath(_settings.RootPath);
+        _rootFullPathWithSeparator = _rootFullPath.EndsWith(Path.DirectorySeparatorChar.ToString(), StringComparison.Ordinal)
+            ? _rootFullPath
+            : _rootFullPath + Path.DirectorySeparatorChar;
+        Directory.CreateDirectory(_rootFullPath);
+    }
+
+    public virtual async Task<FileSaveResult> SaveFileAsync(IFormFile file, string title, CancellationToken ct = default)
+    {
+        if (file.Length == 0) throw new ArgumentException("File is empty", nameof(file));
+
+        if (file.Length > uint.MaxValue)
+        {
+            throw new ArgumentOutOfRangeException(nameof(file),
+                $"File size {file.Length} bytes exceeds maximum supported size of {uint.MaxValue} bytes (4GB)");
+        }
+
+        var extension = Path.GetExtension(file.FileName);
+        if (string.IsNullOrWhiteSpace(extension))
+        {
+            extension = ".bin";
+        }
+
+        var sanitizedTitle = SanitizeTitle(title);
+        var uniqueName = $"{sanitizedTitle}-{Guid.NewGuid():N}{extension}";
+
+        var targetDirectory = GetOrCreateTargetDirectory();
+        var filePath = Path.Combine(targetDirectory, uniqueName);
+
+        await using (var fs = new FileStream(filePath, FileMode.CreateNew, FileAccess.Write, FileShare.None))
+        {
+            await file.CopyToAsync(fs, ct);
+            await fs.FlushAsync(ct);
+        }
+
+        var relative = NormalizeRelativePath(Path.GetRelativePath(_rootFullPath, filePath));
+
+        return new FileSaveResult
+        {
+            Filename = relative,
+            OriginalFilename = file.FileName,
+            FileSizeBytes = (uint)file.Length
+        };
+    }
+
+    public virtual Task DeleteFileAsync(string storedFilename, CancellationToken ct = default)
+    {
+        var fullPath = GetAbsolutePath(storedFilename);
+        if (File.Exists(fullPath))
+        {
+            File.Delete(fullPath);
+        }
+
+        return Task.CompletedTask;
+    }
+
+    public string GetAbsolutePath(string storedFilename)
+    {
+        if (string.IsNullOrWhiteSpace(storedFilename)) throw new ArgumentException("Filename must be provided", nameof(storedFilename));
+
+        var combined = Path.Combine(_rootFullPath, storedFilename);
+        var fullPath = Path.GetFullPath(combined);
+        var isInsideRoot = string.Equals(fullPath, _rootFullPath, StringComparison.Ordinal)
+            || fullPath.StartsWith(_rootFullPathWithSeparator, StringComparison.Ordinal);
+        if (!isInsideRoot)
+        {
+            throw new InvalidOperationException("Attempted to access a file outside of the storage root");
+        }
+
+        return fullPath;
+    }
+
+    protected string GetOrCreateTargetDirectory()
+    {
+        var directories = Directory.GetDirectories(_rootFullPath)
+            .OrderBy(path => path, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+        foreach (var directory in directories)
+        {
+            var fileCount = Directory.GetFiles(directory).Length;
+            if (fileCount < _settings.MaxFilesPerDirectory)
+            {
+                return directory;
+            }
+        }
+
+        var nextIndex = directories
+            .Select(Path.GetFileName)
+            .Select(name => int.TryParse(name, NumberStyles.Integer, CultureInfo.InvariantCulture, out var value) ? value : (int?)null)
+            .Where(value => value.HasValue)
+            .Select(value => value.GetValueOrDefault())
+            .DefaultIfEmpty(0)
+            .Max() + 1;
+
+        var newDirectoryName = nextIndex.ToString("D4", CultureInfo.InvariantCulture);
+        var newDirectoryPath = Path.Combine(_rootFullPath, newDirectoryName);
+        Directory.CreateDirectory(newDirectoryPath);
+        return newDirectoryPath;
+    }
+
+    protected static string NormalizeRelativePath(string relative)
+    {
+        return relative.Replace('\\', '/');
+    }
+
+    protected virtual string DefaultTitleToken => "file";
+
+    protected string SanitizeTitle(string title)
+    {
+        if (string.IsNullOrWhiteSpace(title))
+        {
+            return DefaultTitleToken;
+        }
+
+        var invalidChars = Path.GetInvalidFileNameChars();
+        var sanitizedChars = title
+            .Trim()
+            .ToLowerInvariant()
+            .Select(ch => invalidChars.Contains(ch) ? '-' : ch)
+            .Select(ch => char.IsWhiteSpace(ch) ? '-' : ch)
+            .ToArray();
+
+        var sanitized = new string(sanitizedChars);
+        sanitized = string.Join('-', sanitized
+            .Split('-', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries));
+
+        return string.IsNullOrWhiteSpace(sanitized) ? DefaultTitleToken : sanitized;
+    }
+}

--- a/MediaPi.Core/Services/FileStorageService.cs
+++ b/MediaPi.Core/Services/FileStorageService.cs
@@ -2,6 +2,7 @@
 // This file is a part of Media Pi backend
 
 using System.Globalization;
+using System.Security.Cryptography;
 using Microsoft.Extensions.Options;
 
 using MediaPi.Core.Services.Interfaces;
@@ -31,7 +32,7 @@ public class FileStorageService : IFileStorageService
         Directory.CreateDirectory(_rootFullPath);
     }
 
-    public virtual async Task<FileSaveResult> SaveFileAsync(IFormFile file, string title, CancellationToken ct = default)
+    public virtual async Task<FileSaveResult> SaveFileAsync(IFormFile file, string title, bool computeSha256 = false, CancellationToken ct = default)
     {
         if (file.Length == 0) throw new ArgumentException("File is empty", nameof(file));
 
@@ -42,7 +43,7 @@ public class FileStorageService : IFileStorageService
         }
 
         var extension = Path.GetExtension(file.FileName);
-        if (string.IsNullOrWhiteSpace(extension))
+        if (string.IsNullOrWhiteSpace(extension) || extension == ".")
         {
             extension = ".bin";
         }
@@ -53,8 +54,28 @@ public class FileStorageService : IFileStorageService
         var targetDirectory = GetOrCreateTargetDirectory();
         var filePath = Path.Combine(targetDirectory, uniqueName);
 
-        await using (var fs = new FileStream(filePath, FileMode.CreateNew, FileAccess.Write, FileShare.None))
+        string? sha256Hash = null;
+        if (computeSha256)
         {
+            using var sha256 = SHA256.Create();
+            await using var fs = new FileStream(filePath, new FileStreamOptions
+            {
+                Mode = FileMode.CreateNew,
+                Access = FileAccess.Write,
+                Share = FileShare.None,
+                Options = FileOptions.Asynchronous | FileOptions.SequentialScan
+            });
+            await using (var cs = new CryptoStream(fs, sha256, CryptoStreamMode.Write, leaveOpen: true))
+            {
+                await file.CopyToAsync(cs, ct);
+                await cs.FlushFinalBlockAsync(ct);
+            }
+            await fs.FlushAsync(ct);
+            sha256Hash = BitConverter.ToString(sha256.Hash!).Replace("-", "").ToLowerInvariant();
+        }
+        else
+        {
+            await using var fs = new FileStream(filePath, FileMode.CreateNew, FileAccess.Write, FileShare.None);
             await file.CopyToAsync(fs, ct);
             await fs.FlushAsync(ct);
         }
@@ -65,7 +86,8 @@ public class FileStorageService : IFileStorageService
         {
             Filename = relative,
             OriginalFilename = file.FileName,
-            FileSizeBytes = (uint)file.Length
+            FileSizeBytes = (uint)file.Length,
+            Sha256 = sha256Hash
         };
     }
 

--- a/MediaPi.Core/Services/Interfaces/IFileStorageService.cs
+++ b/MediaPi.Core/Services/Interfaces/IFileStorageService.cs
@@ -1,0 +1,20 @@
+// Copyright (c) 2025-2026 sw.consulting
+// This file is a part of Media Pi backend
+
+using Microsoft.AspNetCore.Http;
+
+namespace MediaPi.Core.Services.Interfaces;
+
+public interface IFileStorageService
+{
+    Task<FileSaveResult> SaveFileAsync(IFormFile file, string title, CancellationToken ct = default);
+    Task DeleteFileAsync(string storedFilename, CancellationToken ct = default);
+    string GetAbsolutePath(string storedFilename);
+}
+
+public class FileSaveResult
+{
+    public required string Filename { get; init; }
+    public required string OriginalFilename { get; init; }
+    public required uint FileSizeBytes { get; init; }
+}

--- a/MediaPi.Core/Services/Interfaces/IFileStorageService.cs
+++ b/MediaPi.Core/Services/Interfaces/IFileStorageService.cs
@@ -7,7 +7,7 @@ namespace MediaPi.Core.Services.Interfaces;
 
 public interface IFileStorageService
 {
-    Task<FileSaveResult> SaveFileAsync(IFormFile file, string title, CancellationToken ct = default);
+    Task<FileSaveResult> SaveFileAsync(IFormFile file, string title, bool computeSha256 = false, CancellationToken ct = default);
     Task DeleteFileAsync(string storedFilename, CancellationToken ct = default);
     string GetAbsolutePath(string storedFilename);
 }
@@ -17,4 +17,5 @@ public class FileSaveResult
     public required string Filename { get; init; }
     public required string OriginalFilename { get; init; }
     public required uint FileSizeBytes { get; init; }
+    public string? Sha256 { get; init; }
 }

--- a/MediaPi.Core/Services/Interfaces/IVideoStorageService.cs
+++ b/MediaPi.Core/Services/Interfaces/IVideoStorageService.cs
@@ -14,5 +14,4 @@ public interface IVideoStorageService : IFileStorageService
 public class VideoSaveResult : FileSaveResult
 {
     public uint? DurationSeconds { get; init; }
-    public string? Sha256 { get; init; }
 }

--- a/MediaPi.Core/Services/Interfaces/IVideoStorageService.cs
+++ b/MediaPi.Core/Services/Interfaces/IVideoStorageService.cs
@@ -5,18 +5,14 @@ using Microsoft.AspNetCore.Http;
 
 namespace MediaPi.Core.Services.Interfaces;
 
-public interface IVideoStorageService
+public interface IVideoStorageService : IFileStorageService
 {
     Task<VideoSaveResult> SaveVideoAsync(IFormFile file, string title, CancellationToken ct = default);
     Task DeleteVideoAsync(string storedFilename, CancellationToken ct = default);
-    string GetAbsolutePath(string storedFilename);
 }
 
-public class VideoSaveResult
+public class VideoSaveResult : FileSaveResult
 {
-    public required string Filename { get; init; }
-    public required string OriginalFilename { get; init; }
-    public required uint FileSizeBytes { get; init; }
     public uint? DurationSeconds { get; init; }
     public string? Sha256 { get; init; }
 }

--- a/MediaPi.Core/Services/VideoStorageService.cs
+++ b/MediaPi.Core/Services/VideoStorageService.cs
@@ -45,7 +45,13 @@ public class VideoStorageService : FileStorageService, IVideoStorageService
 
     private static async Task<string> CalculateSha256Async(string filePath, CancellationToken ct)
     {
-        await using var fs = new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.Read);
+        await using var fs = new FileStream(filePath, new FileStreamOptions
+        {
+            Mode = FileMode.Open,
+            Access = FileAccess.Read,
+            Share = FileShare.Read,
+            Options = FileOptions.Asynchronous | FileOptions.SequentialScan
+        });
         using var sha256 = SHA256.Create();
         var hashBytes = await sha256.ComputeHashAsync(fs, ct);
         return BitConverter.ToString(hashBytes).Replace("-", "").ToLowerInvariant();

--- a/MediaPi.Core/Services/VideoStorageService.cs
+++ b/MediaPi.Core/Services/VideoStorageService.cs
@@ -1,7 +1,6 @@
 // Copyright (c) 2025-2026 sw.consulting
 // This file is a part of Media Pi backend
 
-using System.Security.Cryptography;
 using Microsoft.Extensions.Options;
 
 using MediaPi.Core.Services.Interfaces;
@@ -23,10 +22,9 @@ public class VideoStorageService : FileStorageService, IVideoStorageService
 
     public async Task<VideoSaveResult> SaveVideoAsync(IFormFile file, string title, CancellationToken ct = default)
     {
-        var fileResult = await SaveFileAsync(file, title, ct);
+        var fileResult = await SaveFileAsync(file, title, computeSha256: true, ct);
         var fullPath = GetAbsolutePath(fileResult.Filename);
-        var sha256Hash = await CalculateSha256Async(fullPath, ct);
-        var metadata = await _metadataService.ExtractMetadataAsync(fullPath, ct, sha256Hash);
+        var metadata = await _metadataService.ExtractMetadataAsync(fullPath, ct, fileResult.Sha256);
 
         return new VideoSaveResult
         {
@@ -34,26 +32,12 @@ public class VideoStorageService : FileStorageService, IVideoStorageService
             OriginalFilename = fileResult.OriginalFilename,
             FileSizeBytes = metadata?.FileSizeBytes ?? fileResult.FileSizeBytes,
             DurationSeconds = metadata?.DurationSeconds,
-            Sha256 = sha256Hash
+            Sha256 = fileResult.Sha256
         };
     }
 
     public Task DeleteVideoAsync(string storedFilename, CancellationToken ct = default)
     {
         return DeleteFileAsync(storedFilename, ct);
-    }
-
-    private static async Task<string> CalculateSha256Async(string filePath, CancellationToken ct)
-    {
-        await using var fs = new FileStream(filePath, new FileStreamOptions
-        {
-            Mode = FileMode.Open,
-            Access = FileAccess.Read,
-            Share = FileShare.Read,
-            Options = FileOptions.Asynchronous | FileOptions.SequentialScan
-        });
-        using var sha256 = SHA256.Create();
-        var hashBytes = await sha256.ComputeHashAsync(fs, ct);
-        return BitConverter.ToString(hashBytes).Replace("-", "").ToLowerInvariant();
     }
 }

--- a/MediaPi.Core/Services/VideoStorageService.cs
+++ b/MediaPi.Core/Services/VideoStorageService.cs
@@ -1,7 +1,6 @@
 // Copyright (c) 2025-2026 sw.consulting
 // This file is a part of Media Pi backend
 
-using System.Globalization;
 using System.Security.Cryptography;
 using Microsoft.Extensions.Options;
 
@@ -10,170 +9,45 @@ using MediaPi.Core.Settings;
 
 namespace MediaPi.Core.Services;
 
-public class VideoStorageService : IVideoStorageService
+public class VideoStorageService : FileStorageService, IVideoStorageService
 {
-    private readonly VideoStorageSettings _settings;
     private readonly IVideoMetadataService _metadataService;
-    private readonly string _rootFullPath;
-    private readonly string _rootFullPathWithSeparator;
+
+    protected override string DefaultTitleToken => "video";
 
     public VideoStorageService(IOptions<VideoStorageSettings> options, IVideoMetadataService metadataService)
+        : base(options)
     {
-        _settings = options.Value ?? throw new ArgumentNullException(nameof(options));
         _metadataService = metadataService ?? throw new ArgumentNullException(nameof(metadataService));
-        
-        if (string.IsNullOrWhiteSpace(_settings.RootPath))
-        {
-            throw new ArgumentException("RootPath must be provided", nameof(options));
-        }
-
-        _rootFullPath = Path.GetFullPath(_settings.RootPath);
-        _rootFullPathWithSeparator = _rootFullPath.EndsWith(Path.DirectorySeparatorChar.ToString(), StringComparison.Ordinal)
-            ? _rootFullPath
-            : _rootFullPath + Path.DirectorySeparatorChar;
-        Directory.CreateDirectory(_rootFullPath);
     }
 
     public async Task<VideoSaveResult> SaveVideoAsync(IFormFile file, string title, CancellationToken ct = default)
     {
-        if (file.Length == 0) throw new ArgumentException("File is empty", nameof(file));
-
-        var extension = Path.GetExtension(file.FileName);
-        if (string.IsNullOrWhiteSpace(extension))
-        {
-            extension = ".bin";
-        }
-
-        var sanitizedTitle = SanitizeTitle(title);
-        var uniqueName = $"{sanitizedTitle}-{Guid.NewGuid():N}{extension}";
-
-        var targetDirectory = GetOrCreateTargetDirectory();
-        var filePath = Path.Combine(targetDirectory, uniqueName);
-
-        // Save file and compute SHA256 while writing to disk to avoid a second read
-        string sha256Hash;
-        await using (var fs = new FileStream(filePath, FileMode.CreateNew, FileAccess.Write, FileShare.None))
-        {
-            using var sha256 = SHA256.Create();
-            // Copy stream and compute hash
-            await using var cryptoStream = new CryptoStream(fs, sha256, CryptoStreamMode.Write);
-            await file.CopyToAsync(cryptoStream, ct);
-            // Ensure final block is processed so the hash is finalized
-            cryptoStream.FlushFinalBlock();
-            // Flush underlying file stream
-            await fs.FlushAsync(ct);
-
-            // Finalize hash
-            var hashBytes = sha256.Hash ?? Array.Empty<byte>();
-            sha256Hash = BitConverter.ToString(hashBytes).Replace("-", "").ToLowerInvariant();
-        }
-
-        var relative = NormalizeRelativePath(Path.GetRelativePath(_rootFullPath, filePath));
-
-        // Extract metadata after the file is saved (and the stream has been closed)
-        // Pass the precomputed sha256Hash to avoid re-reading the file
-        var metadata = await _metadataService.ExtractMetadataAsync(filePath, ct, sha256Hash);
-
-        // Convert file size to uint (files larger than 4GB will be capped)
-        if (file.Length > uint.MaxValue)
-        {
-            throw new ArgumentOutOfRangeException(nameof(file), 
-                $"File size {file.Length} bytes exceeds maximum supported size of {uint.MaxValue} bytes (4GB)");
-        }
-        
-        var fileSizeBytes = (uint)file.Length;
+        var fileResult = await SaveFileAsync(file, title, ct);
+        var fullPath = GetAbsolutePath(fileResult.Filename);
+        var sha256Hash = await CalculateSha256Async(fullPath, ct);
+        var metadata = await _metadataService.ExtractMetadataAsync(fullPath, ct, sha256Hash);
 
         return new VideoSaveResult
         {
-            Filename = relative,
-            OriginalFilename = file.FileName,
-            FileSizeBytes = metadata?.FileSizeBytes ?? fileSizeBytes,
+            Filename = fileResult.Filename,
+            OriginalFilename = fileResult.OriginalFilename,
+            FileSizeBytes = metadata?.FileSizeBytes ?? fileResult.FileSizeBytes,
             DurationSeconds = metadata?.DurationSeconds,
-            // return computed sha256
             Sha256 = sha256Hash
         };
     }
 
     public Task DeleteVideoAsync(string storedFilename, CancellationToken ct = default)
     {
-        var fullPath = GetAbsolutePath(storedFilename);
-        if (File.Exists(fullPath))
-        {
-            File.Delete(fullPath);
-        }
-
-        return Task.CompletedTask;
+        return DeleteFileAsync(storedFilename, ct);
     }
 
-    public string GetAbsolutePath(string storedFilename)
+    private static async Task<string> CalculateSha256Async(string filePath, CancellationToken ct)
     {
-        if (string.IsNullOrWhiteSpace(storedFilename)) throw new ArgumentException("Filename must be provided", nameof(storedFilename));
-
-        var combined = Path.Combine(_rootFullPath, storedFilename);
-        var fullPath = Path.GetFullPath(combined);
-        var isInsideRoot = string.Equals(fullPath, _rootFullPath, StringComparison.Ordinal)
-            || fullPath.StartsWith(_rootFullPathWithSeparator, StringComparison.Ordinal);
-        if (!isInsideRoot)
-        {
-            throw new InvalidOperationException("Attempted to access a file outside of the storage root");
-        }
-
-        return fullPath;
-    }
-
-    private string GetOrCreateTargetDirectory()
-    {
-        var directories = Directory.GetDirectories(_rootFullPath)
-            .OrderBy(path => path, StringComparer.OrdinalIgnoreCase)
-            .ToList();
-
-        foreach (var directory in directories)
-        {
-            var fileCount = Directory.GetFiles(directory).Length;
-            if (fileCount < _settings.MaxFilesPerDirectory)
-            {
-                return directory;
-            }
-        }
-
-        var nextIndex = directories
-            .Select(Path.GetFileName)
-            .Select(name => int.TryParse(name, NumberStyles.Integer, CultureInfo.InvariantCulture, out var value) ? value : (int?)null)
-            .Where(value => value.HasValue)
-            .Select(value => value.GetValueOrDefault())
-            .DefaultIfEmpty(0)
-            .Max() + 1;
-
-        var newDirectoryName = nextIndex.ToString("D4", CultureInfo.InvariantCulture);
-        var newDirectoryPath = Path.Combine(_rootFullPath, newDirectoryName);
-        Directory.CreateDirectory(newDirectoryPath);
-        return newDirectoryPath;
-    }
-
-    private static string NormalizeRelativePath(string relative)
-    {
-        return relative.Replace('\\', '/');
-    }
-
-    private static string SanitizeTitle(string title)
-    {
-        if (string.IsNullOrWhiteSpace(title))
-        {
-            return "video";
-        }
-
-        var invalidChars = Path.GetInvalidFileNameChars();
-        var sanitizedChars = title
-            .Trim()
-            .ToLowerInvariant()
-            .Select(ch => invalidChars.Contains(ch) ? '-' : ch)
-            .Select(ch => char.IsWhiteSpace(ch) ? '-' : ch)
-            .ToArray();
-
-        var sanitized = new string(sanitizedChars);
-        sanitized = string.Join('-', sanitized
-            .Split('-', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries));
-
-        return string.IsNullOrWhiteSpace(sanitized) ? "video" : sanitized;
+        await using var fs = new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.Read);
+        using var sha256 = SHA256.Create();
+        var hashBytes = await sha256.ComputeHashAsync(fs, ct);
+        return BitConverter.ToString(hashBytes).Replace("-", "").ToLowerInvariant();
     }
 }


### PR DESCRIPTION
### Motivation
- Separate generic file persistence from video-specific logic so non-video assets (e.g., images/posters) can be stored without video-only metadata requirements. 
- Preserve existing video behavior (duration and SHA256) while reducing duplicated code for saving files and path handling. 

### Description
- Added a generic storage contract `IFileStorageService` and result model `FileSaveResult` to represent non-video save results. 
- Implemented `FileStorageService` with shared behavior: safe root-path handling, directory bucketing, filename sanitization, extension fallback to `.bin` (including trailing-dot filenames), file save/delete, path-traversal protection, and optional on-the-fly SHA256 computation via a `bool computeSha256 = false` parameter. 
- SHA256 is computed during the initial write using a `CryptoStream` — no second file read — and exposed as `FileSaveResult.Sha256`. 
- Refactored `VideoStorageService` to inherit from `FileStorageService`; video-specific work is now limited to calling `IVideoMetadataService` for duration/size. SHA256 is requested from `SaveFileAsync` directly (`computeSha256: true`) and the separate `CalculateSha256Async` method has been removed. 
- Moved `Sha256` property from `VideoSaveResult` to the base `FileSaveResult` so any caller of `SaveFileAsync` can opt into hashing. 
- Updated `IVideoStorageService` so `VideoSaveResult` inherits from `FileSaveResult`. 
- Registered `IFileStorageService` in DI alongside `IVideoStorageService`. 
- Added `FileStorageServiceTests` covering save/delete behavior, title fallback, extension handling, directory limits, and SHA256 opt-in/opt-out behavior. 

### Testing
- Ran `dotnet build MediaPi.sln` which succeeded. 
- Ran `dotnet test MediaPi.sln` and the test suite passed (all tests executed successfully). 
- Ran `dotnet test MediaPi.Core.Tests/MediaPi.Core.Tests.csproj --collect:"XPlat Code Coverage"` which succeeded and produced a coverage report; overall project line-rate is approximately `0.30`, and the newly introduced/modified storage classes show full line-rate coverage in the Cobertura report.

------
<a href="https://chatgpt.com/codex/tasks/task_e_69d0d91f82048321acf021121c94cdea">Codex Task</a>