### PR TITLE
Add ScreenshotStorageService deriving from FileStorageService with camera timestamp extraction

### DIFF
--- a/MediaPi.Core.Tests/Services/ScreenshotStorageServiceTests.cs
+++ b/MediaPi.Core.Tests/Services/ScreenshotStorageServiceTests.cs
@@ -84,7 +84,18 @@ public class ScreenshotStorageServiceTests
 
         var result = await _service.SaveScreenshotAsync(file.Object, "Cam Shot");
 
-        Assert.That(result.TimeCreated, Is.EqualTo(new DateTime(2026, 3, 11, 15, 23, 59)));
+        Assert.That(result.TimeCreated, Is.EqualTo(new DateTime(2026, 3, 11, 15, 23, 59, DateTimeKind.Utc)));
+        Assert.That(result.Sha256, Is.Null);
+    }
+
+    [Test]
+    public async Task SaveScreenshotAsync_WithMatchingCameraBasename_ExtractsTimeCreatedFromFilename()
+    {
+        var file = CreateMockFormFile("cam_2026-03-11_15-23-59.jpg", "image-content");
+
+        var result = await _service.SaveScreenshotAsync(file.Object, "Cam Shot");
+
+        Assert.That(result.TimeCreated, Is.EqualTo(new DateTime(2026, 3, 11, 15, 23, 59, DateTimeKind.Utc)));
         Assert.That(result.Sha256, Is.Null);
     }
 
@@ -103,7 +114,7 @@ public class ScreenshotStorageServiceTests
     [Test]
     public async Task SaveScreenshotAsync_WithInvalidTimestamp_UsesCurrentUtcTime()
     {
-        var file = CreateMockFormFile("/home/pi/Pictures/cam_2026-13-99_99-99-99.jpg", "image-content");
+        var file = CreateMockFormFile("cam_2026-13-99_99-99-99.jpg", "image-content");
         var before = DateTime.UtcNow;
 
         var result = await _service.SaveScreenshotAsync(file.Object, "Cam Shot");

--- a/MediaPi.Core.Tests/Services/ScreenshotStorageServiceTests.cs
+++ b/MediaPi.Core.Tests/Services/ScreenshotStorageServiceTests.cs
@@ -1,0 +1,150 @@
+// Copyright (c) 2025-2026 sw.consulting
+// This file is a part of Media Pi backend
+
+using System;
+using System.Collections.Concurrent;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using MediaPi.Core.Services;
+using MediaPi.Core.Settings;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Options;
+using Moq;
+using NUnit.Framework;
+
+namespace MediaPi.Core.Tests.Services;
+
+[TestFixture]
+public class ScreenshotStorageServiceTests
+{
+    private Mock<IOptions<VideoStorageSettings>> _mockOptions = null!;
+    private VideoStorageSettings _settings = null!;
+    private string _testRootPath = null!;
+    private ScreenshotStorageService _service = null!;
+    private readonly ConcurrentBag<MemoryStream> _memoryStreams = new();
+
+    [SetUp]
+    public void SetUp()
+    {
+        _testRootPath = Path.Combine(Path.GetTempPath(), $"screenshot_storage_test_{Guid.NewGuid()}");
+        Directory.CreateDirectory(_testRootPath);
+
+        _settings = new VideoStorageSettings
+        {
+            RootPath = _testRootPath,
+            MaxFilesPerDirectory = 2
+        };
+
+        _mockOptions = new Mock<IOptions<VideoStorageSettings>>();
+        _mockOptions.Setup(x => x.Value).Returns(_settings);
+        _service = new ScreenshotStorageService(_mockOptions.Object);
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        foreach (var stream in _memoryStreams)
+        {
+            stream.Dispose();
+        }
+
+        _memoryStreams.Clear();
+
+        if (Directory.Exists(_testRootPath))
+        {
+            Directory.Delete(_testRootPath, true);
+        }
+    }
+
+    private Mock<IFormFile> CreateMockFormFile(string fileName, string content)
+    {
+        var mockFile = new Mock<IFormFile>();
+        var ms = new MemoryStream();
+        _memoryStreams.Add(ms);
+        using (var writer = new StreamWriter(ms, leaveOpen: true))
+        {
+            writer.Write(content);
+            writer.Flush();
+        }
+
+        ms.Position = 0;
+        mockFile.Setup(f => f.FileName).Returns(fileName);
+        mockFile.Setup(f => f.Length).Returns(ms.Length);
+        mockFile.Setup(f => f.CopyToAsync(It.IsAny<Stream>(), It.IsAny<CancellationToken>()))
+            .Returns((Stream stream, CancellationToken token) => ms.CopyToAsync(stream, token));
+
+        return mockFile;
+    }
+
+    [Test]
+    public async Task SaveScreenshotAsync_WithMatchingCameraName_ExtractsTimeCreatedFromFilename()
+    {
+        var file = CreateMockFormFile("/home/pi/Pictures/cam_2026-03-11_15-23-59.jpg", "image-content");
+
+        var result = await _service.SaveScreenshotAsync(file.Object, "Cam Shot");
+
+        Assert.That(result.TimeCreated, Is.EqualTo(new DateTime(2026, 3, 11, 15, 23, 59)));
+        Assert.That(result.Sha256, Is.Null);
+    }
+
+    [Test]
+    public async Task SaveScreenshotAsync_WithNonMatchingName_UsesCurrentUtcTime()
+    {
+        var file = CreateMockFormFile("camera-shot.jpg", "image-content");
+        var before = DateTime.UtcNow;
+
+        var result = await _service.SaveScreenshotAsync(file.Object, "Cam Shot");
+
+        var after = DateTime.UtcNow;
+        Assert.That(result.TimeCreated, Is.GreaterThanOrEqualTo(before).And.LessThanOrEqualTo(after));
+    }
+
+    [Test]
+    public async Task SaveScreenshotAsync_WithInvalidTimestamp_UsesCurrentUtcTime()
+    {
+        var file = CreateMockFormFile("/home/pi/Pictures/cam_2026-13-99_99-99-99.jpg", "image-content");
+        var before = DateTime.UtcNow;
+
+        var result = await _service.SaveScreenshotAsync(file.Object, "Cam Shot");
+
+        var after = DateTime.UtcNow;
+        Assert.That(result.TimeCreated, Is.GreaterThanOrEqualTo(before).And.LessThanOrEqualTo(after));
+    }
+
+    [Test]
+    public async Task SaveScreenshotAsync_EmptyTitle_UsesScreenshotFallbackToken()
+    {
+        var file = CreateMockFormFile("shot.jpg", "image-content");
+
+        var result = await _service.SaveScreenshotAsync(file.Object, string.Empty);
+
+        Assert.That(result.Filename, Does.Contain("screenshot"));
+    }
+
+    [Test]
+    public async Task DeleteScreenshotAsync_ExistingFile_DeletesStoredFile()
+    {
+        var file = CreateMockFormFile("shot.jpg", "image-content");
+        var result = await _service.SaveScreenshotAsync(file.Object, "Cam Shot");
+
+        await _service.DeleteScreenshotAsync(result.Filename);
+
+        Assert.That(File.Exists(_service.GetAbsolutePath(result.Filename)), Is.False);
+    }
+
+    [Test]
+    public async Task SaveScreenshotAsync_ReturnsFileStorageFields()
+    {
+        var file = CreateMockFormFile("shot.jpg", "image-content");
+
+        var result = await _service.SaveScreenshotAsync(file.Object, "Title");
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.OriginalFilename, Is.EqualTo("shot.jpg"));
+            Assert.That(result.FileSizeBytes, Is.EqualTo((uint)"image-content".Length));
+            Assert.That(result.Filename, Does.EndWith(".jpg"));
+        });
+    }
+}

--- a/MediaPi.Core/Program.cs
+++ b/MediaPi.Core/Program.cs
@@ -98,6 +98,7 @@ builder.Services.AddHostedService(sp => sp.GetRequiredService<DeviceMonitoringSe
 builder.Services.AddSingleton<IVideoMetadataService, VideoMetadataService>();
 builder.Services.AddSingleton<IFileStorageService, FileStorageService>();
 builder.Services.AddSingleton<IVideoStorageService, VideoStorageService>();
+builder.Services.AddSingleton<IScreenshotStorageService, ScreenshotStorageService>();
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen(c =>
 {

--- a/MediaPi.Core/Services/Interfaces/IScreenshotStorageService.cs
+++ b/MediaPi.Core/Services/Interfaces/IScreenshotStorageService.cs
@@ -1,0 +1,17 @@
+// Copyright (c) 2025-2026 sw.consulting
+// This file is a part of Media Pi backend
+
+using Microsoft.AspNetCore.Http;
+
+namespace MediaPi.Core.Services.Interfaces;
+
+public interface IScreenshotStorageService : IFileStorageService
+{
+    Task<ScreenshotSaveResult> SaveScreenshotAsync(IFormFile file, string title, CancellationToken ct = default);
+    Task DeleteScreenshotAsync(string storedFilename, CancellationToken ct = default);
+}
+
+public class ScreenshotSaveResult : FileSaveResult
+{
+    public required DateTime TimeCreated { get; init; }
+}

--- a/MediaPi.Core/Services/ScreenshotStorageService.cs
+++ b/MediaPi.Core/Services/ScreenshotStorageService.cs
@@ -21,7 +21,7 @@ public partial class ScreenshotStorageService : FileStorageService, IScreenshotS
 
     public async Task<ScreenshotSaveResult> SaveScreenshotAsync(IFormFile file, string title, CancellationToken ct = default)
     {
-        var fileResult = await SaveFileAsync(file, title, computeSha256: false, ct);
+        var fileResult = await SaveFileAsync(file, title, false, ct);
 
         return new ScreenshotSaveResult
         {

--- a/MediaPi.Core/Services/ScreenshotStorageService.cs
+++ b/MediaPi.Core/Services/ScreenshotStorageService.cs
@@ -52,7 +52,7 @@ public partial class ScreenshotStorageService : FileStorageService, IScreenshotS
             return DateTime.UtcNow;
         }
 
-        return parsed;
+        return DateTime.SpecifyKind(parsed, DateTimeKind.Utc);
     }
 
     [GeneratedRegex("^/home/pi/Pictures/cam_(?<timestamp>\\d{4}-\\d{2}-\\d{2}_\\d{2}-\\d{2}-\\d{2})\\.jpg$", RegexOptions.CultureInvariant)]

--- a/MediaPi.Core/Services/ScreenshotStorageService.cs
+++ b/MediaPi.Core/Services/ScreenshotStorageService.cs
@@ -40,7 +40,8 @@ public partial class ScreenshotStorageService : FileStorageService, IScreenshotS
 
     private static DateTime ExtractTimeCreated(string originalFilename)
     {
-        var match = CamScreenshotPattern().Match(originalFilename);
+        var basename = Path.GetFileName(originalFilename);
+        var match = CamScreenshotPattern().Match(basename);
         if (!match.Success)
         {
             return DateTime.UtcNow;
@@ -55,6 +56,6 @@ public partial class ScreenshotStorageService : FileStorageService, IScreenshotS
         return DateTime.SpecifyKind(parsed, DateTimeKind.Utc);
     }
 
-    [GeneratedRegex("^/home/pi/Pictures/cam_(?<timestamp>\\d{4}-\\d{2}-\\d{2}_\\d{2}-\\d{2}-\\d{2})\\.jpg$", RegexOptions.CultureInvariant)]
+    [GeneratedRegex("^cam_(?<timestamp>\\d{4}-\\d{2}-\\d{2}_\\d{2}-\\d{2}-\\d{2})\\.jpg$", RegexOptions.IgnoreCase | RegexOptions.CultureInvariant)]
     private static partial Regex CamScreenshotPattern();
 }

--- a/MediaPi.Core/Services/ScreenshotStorageService.cs
+++ b/MediaPi.Core/Services/ScreenshotStorageService.cs
@@ -1,0 +1,60 @@
+// Copyright (c) 2025-2026 sw.consulting
+// This file is a part of Media Pi backend
+
+using System.Globalization;
+using System.Text.RegularExpressions;
+using Microsoft.Extensions.Options;
+
+using MediaPi.Core.Services.Interfaces;
+using MediaPi.Core.Settings;
+
+namespace MediaPi.Core.Services;
+
+public partial class ScreenshotStorageService : FileStorageService, IScreenshotStorageService
+{
+    protected override string DefaultTitleToken => "screenshot";
+
+    public ScreenshotStorageService(IOptions<VideoStorageSettings> options)
+        : base(options)
+    {
+    }
+
+    public async Task<ScreenshotSaveResult> SaveScreenshotAsync(IFormFile file, string title, CancellationToken ct = default)
+    {
+        var fileResult = await SaveFileAsync(file, title, computeSha256: false, ct);
+
+        return new ScreenshotSaveResult
+        {
+            Filename = fileResult.Filename,
+            OriginalFilename = fileResult.OriginalFilename,
+            FileSizeBytes = fileResult.FileSizeBytes,
+            Sha256 = fileResult.Sha256,
+            TimeCreated = ExtractTimeCreated(fileResult.OriginalFilename)
+        };
+    }
+
+    public Task DeleteScreenshotAsync(string storedFilename, CancellationToken ct = default)
+    {
+        return DeleteFileAsync(storedFilename, ct);
+    }
+
+    private static DateTime ExtractTimeCreated(string originalFilename)
+    {
+        var match = CamScreenshotPattern().Match(originalFilename);
+        if (!match.Success)
+        {
+            return DateTime.UtcNow;
+        }
+
+        var timestamp = match.Groups["timestamp"].Value;
+        if (!DateTime.TryParseExact(timestamp, "yyyy-MM-dd_HH-mm-ss", CultureInfo.InvariantCulture, DateTimeStyles.None, out var parsed))
+        {
+            return DateTime.UtcNow;
+        }
+
+        return parsed;
+    }
+
+    [GeneratedRegex("^/home/pi/Pictures/cam_(?<timestamp>\\d{4}-\\d{2}-\\d{2}_\\d{2}-\\d{2}-\\d{2})\\.jpg$", RegexOptions.CultureInvariant)]
+    private static partial Regex CamScreenshotPattern();
+}


### PR DESCRIPTION
### Motivation
- Provide a dedicated screenshot storage implementation that reuses existing file storage behavior and returns a save result containing the screenshot creation time. 
- When screenshots are produced by the Pi camera with the known naming pattern, preserve the original capture timestamp instead of using the current time.

### Description
- Added `IScreenshotStorageService` and `ScreenshotSaveResult` that inherits from `FileSaveResult` and adds a required `TimeCreated` field. 
- Implemented `ScreenshotStorageService : FileStorageService, IScreenshotStorageService` with `SaveScreenshotAsync` that returns `ScreenshotSaveResult` and `DeleteScreenshotAsync` that delegates to `DeleteFileAsync`.
- `SaveScreenshotAsync` uses a generated regex to match `/home/pi/Pictures/cam_yyyy-MM-dd_HH-mm-ss.jpg` and extracts the `TimeCreated` using `DateTime.TryParseExact`; when the pattern does not match or parsing fails it falls back to `DateTime.UtcNow`.
- Registered `IScreenshotStorageService` in DI (`Program.cs`) and added unit tests in `MediaPi.Core.Tests/Services/ScreenshotStorageServiceTests.cs` covering matching filename, non-matching filename, invalid timestamp, fallback title token, delete flow, and field propagation.

### Testing
- Ran `dotnet test MediaPi.sln` and the full test suite passed (existing tests and new tests) including earlier results of the suite observed as passing.
- Built solution with `dotnet build MediaPi.sln` and it succeeded.
- Ran `dotnet test MediaPi.Core.Tests/MediaPi.Core.Tests.csproj --filter "FullyQualifiedName~ScreenshotStorageServiceTests" --collect:"XPlat Code Coverage"` and the screenshot tests passed (6 tests) and coverage tooling reported `ScreenshotStorageService` line/branch coverage = 100% for the new code paths.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d0f8400cc88321a8484e4e3fe153c0)