### PR TITLE
Add device snapshot creation endpoint with persistence

### DIFF
--- a/MediaPi.Core.Tests/Controllers/DevicesControllerErrorTests.cs
+++ b/MediaPi.Core.Tests/Controllers/DevicesControllerErrorTests.cs
@@ -58,7 +58,7 @@ public class DevicesControllerErrorTests
     [SetUp]
     public void Setup()
     {
-        _dbName = $"device_controller_error_test_db_{System.Guid.NewGuid()}";
+        _dbName = $"device_controller_error_test_db_{Guid.NewGuid()}";
         var options = new DbContextOptionsBuilder<AppDbContext>()
             .UseInMemoryDatabase(_dbName)
             .Options;

--- a/MediaPi.Core.Tests/Controllers/DevicesControllerErrorTests.cs
+++ b/MediaPi.Core.Tests/Controllers/DevicesControllerErrorTests.cs
@@ -52,13 +52,15 @@ public class DevicesControllerErrorTests
     private Mock<IScreenshotStorageService> _screenshotStorageServiceMock;
     private Mock<IMediaPiAgentClient> _agentClientMock;
     private Mock<IMediaPiAgentClient2> _agentClient2Mock;
+    private string _dbName = string.Empty;
 #pragma warning restore CS8618
 
     [SetUp]
     public void Setup()
     {
+        _dbName = $"device_controller_error_test_db_{System.Guid.NewGuid()}";
         var options = new DbContextOptionsBuilder<AppDbContext>()
-            .UseInMemoryDatabase($"device_controller_error_test_db_{System.Guid.NewGuid()}")
+            .UseInMemoryDatabase(_dbName)
             .Options;
 
         _dbContext = new AppDbContext(options);
@@ -563,8 +565,9 @@ public class DevicesControllerErrorTests
         Assert.That(obj!.StatusCode, Is.EqualTo(StatusCodes.Status502BadGateway));
     }
 
+
     [Test]
-    public async Task CreateSnapshot_StorageThrows_ReturnsBadGateway()
+    public async Task CreateSnapshot_StorageThrows_ReturnsInternalServerError()
     {
         SetCurrentUser(_admin.Id);
         _agentClientMock
@@ -582,6 +585,73 @@ public class DevicesControllerErrorTests
         var result = await _controller.CreateSnapshot(1, CancellationToken.None);
         Assert.That(result, Is.TypeOf<ObjectResult>());
         var obj = result as ObjectResult;
-        Assert.That(obj!.StatusCode, Is.EqualTo(StatusCodes.Status502BadGateway));
+        Assert.That(obj!.StatusCode, Is.EqualTo(StatusCodes.Status500InternalServerError));
+    }
+
+    [Test]
+    public async Task CreateSnapshot_DbSaveThrows_DeletesOrphanedFileAndReturnsInternalServerError()
+    {
+        // Use a separate context that throws on SaveChangesAsync, but with the same DB data
+        var throwingOptions = new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase(_dbName)
+            .Options;
+        await using var throwingDb = new ThrowingOnSaveDbContext(throwingOptions);
+
+        SetCurrentUser(_admin.Id);
+        var savedFilename = "0001/snapshot.jpg";
+        _agentClientMock
+            .Setup(c => c.CreateSnapshotAsync(It.Is<Device>(d => d.Id == 1), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new DeviceSnapshotResult
+            {
+                Content = [1, 2],
+                ContentType = "image/jpeg",
+                Filename = "snapshot.jpg"
+            });
+        _screenshotStorageServiceMock
+            .Setup(s => s.SaveScreenshotAsync(It.IsAny<IFormFile>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ScreenshotSaveResult
+            {
+                Filename = savedFilename,
+                OriginalFilename = "snapshot.jpg",
+                FileSizeBytes = 2,
+                Sha256 = "abc",
+                TimeCreated = DateTime.UtcNow
+            });
+        _screenshotStorageServiceMock
+            .Setup(s => s.DeleteScreenshotAsync(savedFilename, It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        var throwingController = new DevicesController(
+            _mockHttpContextAccessor.Object,
+            _userInformationService,
+            throwingDb,
+            _mockLogger.Object,
+            _deviceEventsService,
+            _monitoringServiceMock.Object,
+            _screenshotStorageServiceMock.Object,
+            _agentClientMock.Object,
+            _agentClient2Mock.Object
+        )
+        {
+            ControllerContext = new ControllerContext
+            {
+                HttpContext = _mockHttpContextAccessor.Object.HttpContext!
+            }
+        };
+
+        var result = await throwingController.CreateSnapshot(1, CancellationToken.None);
+
+        Assert.That(result, Is.TypeOf<ObjectResult>());
+        var obj = result as ObjectResult;
+        Assert.That(obj!.StatusCode, Is.EqualTo(StatusCodes.Status500InternalServerError));
+        _screenshotStorageServiceMock.Verify(
+            s => s.DeleteScreenshotAsync(savedFilename, It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    private sealed class ThrowingOnSaveDbContext(DbContextOptions<AppDbContext> options) : AppDbContext(options)
+    {
+        public override Task<int> SaveChangesAsync(CancellationToken cancellationToken = default)
+            => throw new DbUpdateException("Simulated DB failure");
     }
 }

--- a/MediaPi.Core.Tests/Controllers/DevicesControllerErrorTests.cs
+++ b/MediaPi.Core.Tests/Controllers/DevicesControllerErrorTests.cs
@@ -10,6 +10,7 @@ using Moq;
 using NUnit.Framework;
 
 using System;
+using System.IO;
 using System.Linq;
 using System.Net;
 using System.Text.Json;
@@ -48,6 +49,7 @@ public class DevicesControllerErrorTests
     private UserInformationService _userInformationService;
     private DeviceEventsService _deviceEventsService;
     private Mock<IDeviceMonitoringService> _monitoringServiceMock;
+    private Mock<IScreenshotStorageService> _screenshotStorageServiceMock;
     private Mock<IMediaPiAgentClient> _agentClientMock;
     private Mock<IMediaPiAgentClient2> _agentClient2Mock;
 #pragma warning restore CS8618
@@ -62,6 +64,7 @@ public class DevicesControllerErrorTests
         _dbContext = new AppDbContext(options);
         _deviceEventsService = new DeviceEventsService();
         _monitoringServiceMock = new Mock<IDeviceMonitoringService>();
+        _screenshotStorageServiceMock = new Mock<IScreenshotStorageService>();
         _agentClientMock = new Mock<IMediaPiAgentClient>();
         _agentClient2Mock = new Mock<IMediaPiAgentClient2>();
 
@@ -135,6 +138,7 @@ public class DevicesControllerErrorTests
             _mockLogger.Object,
             _deviceEventsService,
             _monitoringServiceMock.Object,
+            _screenshotStorageServiceMock.Object,
             _agentClientMock.Object,
             _agentClient2Mock.Object
         )
@@ -531,6 +535,53 @@ public class DevicesControllerErrorTests
 
         Assert.That(result.Result, Is.TypeOf<ObjectResult>());
         var obj = result.Result as ObjectResult;
+        Assert.That(obj!.StatusCode, Is.EqualTo(StatusCodes.Status502BadGateway));
+    }
+
+    [Test]
+    public async Task CreateSnapshot_EngineerAssignedDevice_ReturnsForbidden()
+    {
+        SetCurrentUser(_engineer.Id);
+        var result = await _controller.CreateSnapshot(1, CancellationToken.None);
+        Assert.That(result, Is.TypeOf<ObjectResult>());
+        var obj = result as ObjectResult;
+        Assert.That(obj!.StatusCode, Is.EqualTo(StatusCodes.Status403Forbidden));
+        _agentClientMock.Verify(c => c.CreateSnapshotAsync(It.IsAny<Device>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Test]
+    public async Task CreateSnapshot_AgentThrows_ReturnsBadGateway()
+    {
+        SetCurrentUser(_admin.Id);
+        _agentClientMock
+            .Setup(c => c.CreateSnapshotAsync(It.Is<Device>(d => d.Id == 1), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("snapshot failed"));
+
+        var result = await _controller.CreateSnapshot(1, CancellationToken.None);
+        Assert.That(result, Is.TypeOf<ObjectResult>());
+        var obj = result as ObjectResult;
+        Assert.That(obj!.StatusCode, Is.EqualTo(StatusCodes.Status502BadGateway));
+    }
+
+    [Test]
+    public async Task CreateSnapshot_StorageThrows_ReturnsBadGateway()
+    {
+        SetCurrentUser(_admin.Id);
+        _agentClientMock
+            .Setup(c => c.CreateSnapshotAsync(It.Is<Device>(d => d.Id == 1), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new DeviceSnapshotResult
+            {
+                Content = [1, 2],
+                ContentType = "image/jpeg",
+                Filename = "snapshot.jpg"
+            });
+        _screenshotStorageServiceMock
+            .Setup(s => s.SaveScreenshotAsync(It.IsAny<IFormFile>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new IOException("disk full"));
+
+        var result = await _controller.CreateSnapshot(1, CancellationToken.None);
+        Assert.That(result, Is.TypeOf<ObjectResult>());
+        var obj = result as ObjectResult;
         Assert.That(obj!.StatusCode, Is.EqualTo(StatusCodes.Status502BadGateway));
     }
 }

--- a/MediaPi.Core.Tests/Controllers/DevicesControllerTests.cs
+++ b/MediaPi.Core.Tests/Controllers/DevicesControllerTests.cs
@@ -48,6 +48,7 @@ public class DevicesControllerTests
     private UserInformationService _userInformationService;
     private DeviceEventsService _deviceEventsService;
     private Mock<IDeviceMonitoringService> _monitoringServiceMock;
+    private Mock<IScreenshotStorageService> _screenshotStorageServiceMock;
     private Mock<IMediaPiAgentClient> _agentClientMock;
     private Mock<IMediaPiAgentClient2> _agentClient2Mock;
 #pragma warning restore CS8618
@@ -62,6 +63,7 @@ public class DevicesControllerTests
         _dbContext = new AppDbContext(options);
         _deviceEventsService = new DeviceEventsService();
         _monitoringServiceMock = new Mock<IDeviceMonitoringService>();
+        _screenshotStorageServiceMock = new Mock<IScreenshotStorageService>();
         _agentClientMock = new Mock<IMediaPiAgentClient>();
         _agentClient2Mock = new Mock<IMediaPiAgentClient2>();
 
@@ -131,6 +133,7 @@ public class DevicesControllerTests
             _mockLogger.Object,
             _deviceEventsService,
             _monitoringServiceMock.Object,
+            _screenshotStorageServiceMock.Object,
             _agentClientMock.Object,
             _agentClient2Mock.Object
         )
@@ -1315,5 +1318,72 @@ public class DevicesControllerTests
         Assert.That(result.Result, Is.TypeOf<ObjectResult>());
         var obj = result.Result as ObjectResult;
         Assert.That(obj!.StatusCode, Is.EqualTo(StatusCodes.Status502BadGateway));
+    }
+
+    [Test]
+    public async Task CreateSnapshot_Admin_SavesScreenshotAndReturnsFile()
+    {
+        SetCurrentUser(_admin.Id);
+        var imageContent = new byte[] { 1, 2, 3, 4, 5 };
+        _agentClientMock
+            .Setup(c => c.CreateSnapshotAsync(It.Is<Device>(d => d.Id == 1), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new DeviceSnapshotResult
+            {
+                Content = imageContent,
+                ContentType = "image/jpeg",
+                Filename = "cam_2026-04-14_12-00-00.jpg"
+            });
+
+        _screenshotStorageServiceMock
+            .Setup(s => s.SaveScreenshotAsync(It.IsAny<IFormFile>(), "cam_2026-04-14_12-00-00", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ScreenshotSaveResult
+            {
+                Filename = "0001/cam_2026-04-14_12-00-00.jpg",
+                OriginalFilename = "cam_2026-04-14_12-00-00.jpg",
+                FileSizeBytes = 5,
+                Sha256 = "hash",
+                TimeCreated = new DateTime(2026, 4, 14, 12, 0, 0, DateTimeKind.Utc)
+            });
+
+        var result = await _controller.CreateSnapshot(1, CancellationToken.None);
+
+        Assert.That(result, Is.TypeOf<FileContentResult>());
+        var file = (FileContentResult)result;
+        Assert.That(file.FileContents, Is.EqualTo(imageContent));
+        Assert.That(file.ContentType, Is.EqualTo("image/jpeg"));
+        Assert.That(file.FileDownloadName, Is.EqualTo("cam_2026-04-14_12-00-00.jpg"));
+
+        var screenshot = await _dbContext.Screenshots.OrderByDescending(s => s.Id).FirstOrDefaultAsync();
+        Assert.That(screenshot, Is.Not.Null);
+        Assert.That(screenshot!.DeviceId, Is.EqualTo(1));
+        Assert.That(screenshot.Filename, Is.EqualTo("0001/cam_2026-04-14_12-00-00.jpg"));
+        Assert.That(screenshot.OriginalFilename, Is.EqualTo("cam_2026-04-14_12-00-00.jpg"));
+    }
+
+    [Test]
+    public async Task CreateSnapshot_Manager_OwnDevice_Succeeds()
+    {
+        SetCurrentUser(_manager.Id);
+        _agentClientMock
+            .Setup(c => c.CreateSnapshotAsync(It.Is<Device>(d => d.Id == 1), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new DeviceSnapshotResult
+            {
+                Content = [9, 9, 9],
+                ContentType = "image/png",
+                Filename = "snapshot.png"
+            });
+        _screenshotStorageServiceMock
+            .Setup(s => s.SaveScreenshotAsync(It.IsAny<IFormFile>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ScreenshotSaveResult
+            {
+                Filename = "0001/snapshot.png",
+                OriginalFilename = "snapshot.png",
+                FileSizeBytes = 3,
+                Sha256 = "sha",
+                TimeCreated = DateTime.UtcNow
+            });
+
+        var result = await _controller.CreateSnapshot(1, CancellationToken.None);
+        Assert.That(result, Is.TypeOf<FileContentResult>());
     }
 }

--- a/MediaPi.Core.Tests/Services/DeviceAgentRestClientTests.cs
+++ b/MediaPi.Core.Tests/Services/DeviceAgentRestClientTests.cs
@@ -394,6 +394,49 @@ public class DeviceAgentRestClientTests
         Assert.ThrowsAsync<TimeoutException>(() => client.GetStatusAsync(device, "unit", CancellationToken.None));
     }
 
+    [Test]
+    public async Task CreateSnapshotAsync_ReturnsImagePayload()
+    {
+        HttpMethod? observedMethod = null;
+        Uri? observedUri = null;
+        var bytes = new byte[] { 10, 20, 30 };
+
+        var handler = new StubHttpMessageHandler((request, _) =>
+        {
+            observedMethod = request.Method;
+            observedUri = request.RequestUri;
+
+            var response = new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new ByteArrayContent(bytes)
+            };
+            response.Content.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue("image/png");
+            response.Content.Headers.ContentDisposition = new System.Net.Http.Headers.ContentDispositionHeaderValue("attachment")
+            {
+                FileName = "\"from-device.png\""
+            };
+            return Task.FromResult(response);
+        });
+
+        var client = CreateClient(handler);
+        var result = await client.CreateSnapshotAsync(CreateDevice(ip: "10.0.0.8", port: 8086), CancellationToken.None);
+
+        Assert.That(observedMethod, Is.EqualTo(HttpMethod.Post));
+        Assert.That(observedUri, Is.Not.Null);
+        Assert.That(observedUri!.AbsolutePath, Is.EqualTo("/api/snapshot"));
+        Assert.That(result.Content, Is.EqualTo(bytes));
+        Assert.That(result.ContentType, Is.EqualTo("image/png"));
+        Assert.That(result.Filename, Is.EqualTo("from-device.png"));
+    }
+
+    [Test]
+    public void CreateSnapshotAsync_WhenEndpointFails_Throws()
+    {
+        var handler = new StubHttpMessageHandler((_, _) => Task.FromResult(new HttpResponseMessage(HttpStatusCode.BadGateway)));
+        var client = CreateClient(handler);
+        Assert.ThrowsAsync<InvalidOperationException>(() => client.CreateSnapshotAsync(CreateDevice(), CancellationToken.None));
+    }
+
     private static DeviceAgentRestClient CreateClient(HttpMessageHandler handler, TestLogger<DeviceAgentRestClient>? logger = null)
     {
         var httpClient = new HttpClient(handler);

--- a/MediaPi.Core.Tests/Services/DeviceAgentRestClientTests.cs
+++ b/MediaPi.Core.Tests/Services/DeviceAgentRestClientTests.cs
@@ -555,6 +555,7 @@ public class DeviceAgentRestClientTests
         var result = await client.CreateSnapshotAsync(CreateDevice(), CancellationToken.None);
 
         Assert.That(result.Filename.Length, Is.LessThanOrEqualTo(200));
+        Assert.That(result.Filename, Does.EndWith(".jpg"));
     }
 
     private static DeviceAgentRestClient CreateClient(HttpMessageHandler handler, TestLogger<DeviceAgentRestClient>? logger = null)

--- a/MediaPi.Core.Tests/Services/DeviceAgentRestClientTests.cs
+++ b/MediaPi.Core.Tests/Services/DeviceAgentRestClientTests.cs
@@ -437,6 +437,77 @@ public class DeviceAgentRestClientTests
         Assert.ThrowsAsync<InvalidOperationException>(() => client.CreateSnapshotAsync(CreateDevice(), CancellationToken.None));
     }
 
+    [Test]
+    public async Task CreateSnapshotAsync_NonImageContentType_FallsBackToJpeg()
+    {
+        var bytes = new byte[] { 1, 2, 3 };
+        var handler = new StubHttpMessageHandler((_, _) =>
+        {
+            var response = new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new ByteArrayContent(bytes)
+            };
+            response.Content.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue("text/html");
+            return Task.FromResult(response);
+        });
+
+        var client = CreateClient(handler);
+        var result = await client.CreateSnapshotAsync(CreateDevice(), CancellationToken.None);
+
+        Assert.That(result.ContentType, Is.EqualTo("image/jpeg"));
+    }
+
+    [Test]
+    public async Task CreateSnapshotAsync_FilenameWithPathTraversal_IsNormalized()
+    {
+        var bytes = new byte[] { 1, 2, 3 };
+        var handler = new StubHttpMessageHandler((_, _) =>
+        {
+            var response = new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new ByteArrayContent(bytes)
+            };
+            response.Content.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue("image/jpeg");
+            response.Content.Headers.ContentDisposition = new System.Net.Http.Headers.ContentDispositionHeaderValue("attachment")
+            {
+                FileName = "\"../../etc/passwd\""
+            };
+            return Task.FromResult(response);
+        });
+
+        var client = CreateClient(handler);
+        var result = await client.CreateSnapshotAsync(CreateDevice(), CancellationToken.None);
+
+        Assert.That(result.Filename, Is.EqualTo("passwd"));
+    }
+
+    [Test]
+    public async Task CreateSnapshotAsync_FilenameWithInvalidChars_AreReplaced()
+    {
+        var bytes = new byte[] { 1, 2, 3 };
+        var handler = new StubHttpMessageHandler((_, _) =>
+        {
+            var response = new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new ByteArrayContent(bytes)
+            };
+            response.Content.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue("image/png");
+            response.Content.Headers.ContentDisposition = new System.Net.Http.Headers.ContentDispositionHeaderValue("attachment")
+            {
+                FileName = "\"snap|shot<name>.png\""
+            };
+            return Task.FromResult(response);
+        });
+
+        var client = CreateClient(handler);
+        var result = await client.CreateSnapshotAsync(CreateDevice(), CancellationToken.None);
+
+        Assert.That(result.Filename, Does.Not.Contain("|"));
+        Assert.That(result.Filename, Does.Not.Contain("<"));
+        Assert.That(result.Filename, Does.Not.Contain(">"));
+        Assert.That(result.Filename, Does.EndWith(".png"));
+    }
+
     private static DeviceAgentRestClient CreateClient(HttpMessageHandler handler, TestLogger<DeviceAgentRestClient>? logger = null)
     {
         var httpClient = new HttpClient(handler);

--- a/MediaPi.Core.Tests/Services/DeviceAgentRestClientTests.cs
+++ b/MediaPi.Core.Tests/Services/DeviceAgentRestClientTests.cs
@@ -508,6 +508,55 @@ public class DeviceAgentRestClientTests
         Assert.That(result.Filename, Does.EndWith(".png"));
     }
 
+    [Test]
+    public async Task CreateSnapshotAsync_FilenameWithControlChars_AreReplaced()
+    {
+        var bytes = new byte[] { 1, 2, 3 };
+        var handler = new StubHttpMessageHandler((_, _) =>
+        {
+            var response = new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new ByteArrayContent(bytes)
+            };
+            response.Content.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue("image/jpeg");
+            // Set raw header to bypass HttpClient header validation which rejects control chars
+            response.Content.Headers.TryAddWithoutValidation(
+                "Content-Disposition", "attachment; filename=\"snap\x0Bshot.jpg\"");
+            return Task.FromResult(response);
+        });
+
+        var client = CreateClient(handler);
+        var result = await client.CreateSnapshotAsync(CreateDevice(), CancellationToken.None);
+
+        Assert.That(result.Filename, Does.Not.Contain("\x0B"));
+        Assert.That(result.Filename, Does.EndWith(".jpg"));
+    }
+
+    [Test]
+    public async Task CreateSnapshotAsync_ExcessivelyLongFilename_IsTrimmed()
+    {
+        var bytes = new byte[] { 1, 2, 3 };
+        var longName = new string('a', 300) + ".jpg";
+        var handler = new StubHttpMessageHandler((_, _) =>
+        {
+            var response = new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new ByteArrayContent(bytes)
+            };
+            response.Content.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue("image/jpeg");
+            response.Content.Headers.ContentDisposition = new System.Net.Http.Headers.ContentDispositionHeaderValue("attachment")
+            {
+                FileName = $"\"{longName}\""
+            };
+            return Task.FromResult(response);
+        });
+
+        var client = CreateClient(handler);
+        var result = await client.CreateSnapshotAsync(CreateDevice(), CancellationToken.None);
+
+        Assert.That(result.Filename.Length, Is.LessThanOrEqualTo(200));
+    }
+
     private static DeviceAgentRestClient CreateClient(HttpMessageHandler handler, TestLogger<DeviceAgentRestClient>? logger = null)
     {
         var httpClient = new HttpClient(handler);

--- a/MediaPi.Core/Controllers/DevicesController.Menu.cs
+++ b/MediaPi.Core/Controllers/DevicesController.Menu.cs
@@ -5,6 +5,7 @@ using System.Text.Json;
 using MediaPi.Core.Models;
 using MediaPi.Core.RestModels;
 using MediaPi.Core.RestModels.Device;
+using MediaPi.Core.Services.Interfaces;
 using MediaPi.Core.Services.Models;
 using Microsoft.AspNetCore.Mvc;
 
@@ -25,7 +26,7 @@ public partial class DevicesController
 
         var targetDevice = device!;
 
-        MediaPi.Core.Services.Models.SnapshotResponse snapshot;
+        DeviceSnapshotResult snapshot;
         try
         {
             snapshot = await mediaPiAgentClient.CreateSnapshotAsync(targetDevice, ct);
@@ -45,7 +46,17 @@ public partial class DevicesController
             ContentType = snapshot.ContentType
         };
 
-        var saveResult = await screenshotStorageService.SaveScreenshotAsync(formFile, Path.GetFileNameWithoutExtension(snapshot.Filename), ct);
+        ScreenshotSaveResult saveResult;
+        try
+        {
+            saveResult = await screenshotStorageService.SaveScreenshotAsync(formFile, Path.GetFileNameWithoutExtension(snapshot.Filename), ct);
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Ошибка при сохранении снимка экрана для устройства {DeviceId}", id);
+            return _500SnapshotPersistence();
+        }
+
         var screenshot = new Screenshot
         {
             Filename = saveResult.Filename,
@@ -55,8 +66,24 @@ public partial class DevicesController
             DeviceId = id
         };
 
-        _db.Screenshots.Add(screenshot);
-        await _db.SaveChangesAsync(ct);
+        try
+        {
+            _db.Screenshots.Add(screenshot);
+            await _db.SaveChangesAsync(ct);
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Ошибка при сохранении записи снимка экрана для устройства {DeviceId}", id);
+            try
+            {
+                await screenshotStorageService.DeleteScreenshotAsync(saveResult.Filename, ct);
+            }
+            catch (Exception deleteEx)
+            {
+                logger.LogError(deleteEx, "Не удалось удалить осиротевший файл снимка {Filename}", saveResult.Filename);
+            }
+            return _500SnapshotPersistence();
+        }
 
         return File(snapshot.Content, snapshot.ContentType, snapshot.Filename);
     }

--- a/MediaPi.Core/Controllers/DevicesController.Menu.cs
+++ b/MediaPi.Core/Controllers/DevicesController.Menu.cs
@@ -27,7 +27,8 @@ public partial class DevicesController
         try
         {
             var snapshot = await mediaPiAgentClient.CreateSnapshotAsync(targetDevice, ct);
-            var formFile = new FormFile(new MemoryStream(snapshot.Content), 0, snapshot.Content.Length, "file", snapshot.Filename)
+            await using var stream = new MemoryStream(snapshot.Content);
+            var formFile = new FormFile(stream, 0, snapshot.Content.Length, "file", snapshot.Filename)
             {
                 Headers = new HeaderDictionary(),
                 ContentType = snapshot.ContentType

--- a/MediaPi.Core/Controllers/DevicesController.Menu.cs
+++ b/MediaPi.Core/Controllers/DevicesController.Menu.cs
@@ -2,6 +2,7 @@
 // This file is a part of Media Pi backend
 
 using System.Text.Json;
+using MediaPi.Core.Models;
 using MediaPi.Core.RestModels;
 using MediaPi.Core.RestModels.Device;
 using MediaPi.Core.Services.Models;
@@ -11,6 +12,49 @@ namespace MediaPi.Core.Controllers;
 
 public partial class DevicesController
 {
+    [HttpPost("{id}/snapshot")]
+    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(FileContentResult))]
+    [ProducesResponseType(StatusCodes.Status403Forbidden, Type = typeof(ErrMessage))]
+    [ProducesResponseType(StatusCodes.Status404NotFound, Type = typeof(ErrMessage))]
+    [ProducesResponseType(StatusCodes.Status502BadGateway, Type = typeof(ErrMessage))]
+    public async Task<IActionResult> CreateSnapshot(int id, CancellationToken ct = default)
+    {
+        var (device, error) = await GetDeviceForServiceAsync(id, ct);
+        if (error != null) return error;
+
+        var targetDevice = device!;
+
+        try
+        {
+            var snapshot = await mediaPiAgentClient.CreateSnapshotAsync(targetDevice, ct);
+            var formFile = new FormFile(new MemoryStream(snapshot.Content), 0, snapshot.Content.Length, "file", snapshot.Filename)
+            {
+                Headers = new HeaderDictionary(),
+                ContentType = snapshot.ContentType
+            };
+
+            var saveResult = await screenshotStorageService.SaveScreenshotAsync(formFile, Path.GetFileNameWithoutExtension(snapshot.Filename), ct);
+            var screenshot = new Screenshot
+            {
+                Filename = saveResult.Filename,
+                OriginalFilename = saveResult.OriginalFilename,
+                FileSizeBytes = saveResult.FileSizeBytes,
+                TimeCreated = saveResult.TimeCreated,
+                DeviceId = id
+            };
+
+            _db.Screenshots.Add(screenshot);
+            await _db.SaveChangesAsync(ct);
+
+            return File(snapshot.Content, snapshot.ContentType, snapshot.Filename);
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Ошибка при выполнении операции create snapshot для устройства {DeviceId}", id);
+            return _502Agent();
+        }
+    }
+
     [HttpPost("{id}/playback/stop")]
     [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(MediaPiMenuCommandResponse))]
     [ProducesResponseType(StatusCodes.Status403Forbidden, Type = typeof(ErrMessage))]

--- a/MediaPi.Core/Controllers/DevicesController.Menu.cs
+++ b/MediaPi.Core/Controllers/DevicesController.Menu.cs
@@ -27,6 +27,9 @@ public partial class DevicesController
         try
         {
             var snapshot = await mediaPiAgentClient.CreateSnapshotAsync(targetDevice, ct);
+
+            // Stream must remain open for the duration of SaveScreenshotAsync; it is disposed
+            // at the end of this try block, after the save call has completed.
             await using var stream = new MemoryStream(snapshot.Content);
             var formFile = new FormFile(stream, 0, snapshot.Content.Length, "file", snapshot.Filename)
             {

--- a/MediaPi.Core/Controllers/DevicesController.Menu.cs
+++ b/MediaPi.Core/Controllers/DevicesController.Menu.cs
@@ -16,6 +16,7 @@ public partial class DevicesController
     [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(FileContentResult))]
     [ProducesResponseType(StatusCodes.Status403Forbidden, Type = typeof(ErrMessage))]
     [ProducesResponseType(StatusCodes.Status404NotFound, Type = typeof(ErrMessage))]
+    [ProducesResponseType(StatusCodes.Status500InternalServerError, Type = typeof(ErrMessage))]
     [ProducesResponseType(StatusCodes.Status502BadGateway, Type = typeof(ErrMessage))]
     public async Task<IActionResult> CreateSnapshot(int id, CancellationToken ct = default)
     {
@@ -24,39 +25,40 @@ public partial class DevicesController
 
         var targetDevice = device!;
 
+        MediaPi.Core.Services.Models.SnapshotResponse snapshot;
         try
         {
-            var snapshot = await mediaPiAgentClient.CreateSnapshotAsync(targetDevice, ct);
-
-            // Stream must remain open for the duration of SaveScreenshotAsync; it is disposed
-            // at the end of this try block, after the save call has completed.
-            await using var stream = new MemoryStream(snapshot.Content);
-            var formFile = new FormFile(stream, 0, snapshot.Content.Length, "file", snapshot.Filename)
-            {
-                Headers = new HeaderDictionary(),
-                ContentType = snapshot.ContentType
-            };
-
-            var saveResult = await screenshotStorageService.SaveScreenshotAsync(formFile, Path.GetFileNameWithoutExtension(snapshot.Filename), ct);
-            var screenshot = new Screenshot
-            {
-                Filename = saveResult.Filename,
-                OriginalFilename = saveResult.OriginalFilename,
-                FileSizeBytes = saveResult.FileSizeBytes,
-                TimeCreated = saveResult.TimeCreated,
-                DeviceId = id
-            };
-
-            _db.Screenshots.Add(screenshot);
-            await _db.SaveChangesAsync(ct);
-
-            return File(snapshot.Content, snapshot.ContentType, snapshot.Filename);
+            snapshot = await mediaPiAgentClient.CreateSnapshotAsync(targetDevice, ct);
         }
         catch (Exception ex)
         {
             logger.LogError(ex, "Ошибка при выполнении операции create snapshot для устройства {DeviceId}", id);
             return _502Agent();
         }
+
+        // Stream must remain open for the duration of SaveScreenshotAsync; it is disposed
+        // at the end of this method scope, after the save call has completed.
+        await using var stream = new MemoryStream(snapshot.Content);
+        var formFile = new FormFile(stream, 0, snapshot.Content.Length, "file", snapshot.Filename)
+        {
+            Headers = new HeaderDictionary(),
+            ContentType = snapshot.ContentType
+        };
+
+        var saveResult = await screenshotStorageService.SaveScreenshotAsync(formFile, Path.GetFileNameWithoutExtension(snapshot.Filename), ct);
+        var screenshot = new Screenshot
+        {
+            Filename = saveResult.Filename,
+            OriginalFilename = saveResult.OriginalFilename,
+            FileSizeBytes = saveResult.FileSizeBytes,
+            TimeCreated = saveResult.TimeCreated,
+            DeviceId = id
+        };
+
+        _db.Screenshots.Add(screenshot);
+        await _db.SaveChangesAsync(ct);
+
+        return File(snapshot.Content, snapshot.ContentType, snapshot.Filename);
     }
 
     [HttpPost("{id}/playback/stop")]

--- a/MediaPi.Core/Controllers/DevicesController.cs
+++ b/MediaPi.Core/Controllers/DevicesController.cs
@@ -27,6 +27,7 @@ public partial class DevicesController(
     ILogger<DevicesController> logger,
     DeviceEventsService deviceEventsService,
     IDeviceMonitoringService monitoringService,
+    IScreenshotStorageService screenshotStorageService,
     IMediaPiAgentClient mediaPiAgentClient,
     IMediaPiAgentClient2 mediaPiAgentClient2) : MediaPiControllerBase(httpContextAccessor, db, logger)
 {

--- a/MediaPi.Core/Controllers/MediaPiControllerBase.cs
+++ b/MediaPi.Core/Controllers/MediaPiControllerBase.cs
@@ -216,6 +216,12 @@ public class MediaPiControllerPreBase(AppDbContext db, ILogger logger) : Control
                           new ErrMessage { Msg = "Middleware авторизации устройства не установил DeviceId" });
     }
 
+    protected ObjectResult _500SnapshotPersistence()
+    {
+        return StatusCode(StatusCodes.Status500InternalServerError,
+                          new ErrMessage { Msg = "Внутренняя ошибка при сохранении снимка экрана" });
+    }
+
     protected ObjectResult _403DeviceUnauthorizedVideo(int deviceId, int videoId)
     {
         return StatusCode(StatusCodes.Status403Forbidden,

--- a/MediaPi.Core/Services/DeviceAgentRestClient.cs
+++ b/MediaPi.Core/Services/DeviceAgentRestClient.cs
@@ -6,6 +6,7 @@ using System.Net.Http.Headers;
 using System.Text;
 using System.Text.Json;
 using System.Linq;
+using Microsoft.AspNetCore.StaticFiles;
 using MediaPi.Core.Models;
 using MediaPi.Core.Services.Interfaces;
 using MediaPi.Core.Services.Models;
@@ -21,6 +22,7 @@ public sealed class DeviceAgentRestClient : IMediaPiAgentClient
 
     private readonly HttpClient _httpClient;
     private readonly ILogger<DeviceAgentRestClient> _logger;
+    private static readonly FileExtensionContentTypeProvider ContentTypeProvider = new();
 
     public DeviceAgentRestClient(HttpClient httpClient, ILogger<DeviceAgentRestClient> logger)
     {
@@ -84,6 +86,37 @@ public sealed class DeviceAgentRestClient : IMediaPiAgentClient
             Status = data?.Status,
             Uptime = data?.Uptime,
             Version = data?.Version
+        };
+    }
+
+    public async Task<DeviceSnapshotResult> CreateSnapshotAsync(Device device, CancellationToken cancellationToken = default)
+    {
+        using var request = CreateRequest(device, HttpMethod.Post, "/api/snapshot");
+        using var response = await _httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
+
+        if (!response.IsSuccessStatusCode)
+        {
+            throw new InvalidOperationException($"Snapshot endpoint returned status {(int)response.StatusCode} ({response.StatusCode}).");
+        }
+
+        var content = await response.Content.ReadAsByteArrayAsync(cancellationToken).ConfigureAwait(false);
+        if (content.Length == 0)
+        {
+            throw new InvalidOperationException("Snapshot endpoint returned an empty response body.");
+        }
+
+        var contentType = response.Content.Headers.ContentType?.MediaType;
+        if (string.IsNullOrWhiteSpace(contentType))
+        {
+            contentType = "image/jpeg";
+        }
+
+        var filename = ResolveSnapshotFilename(response, contentType);
+        return new DeviceSnapshotResult
+        {
+            Content = content,
+            ContentType = contentType,
+            Filename = filename
         };
     }
 
@@ -217,6 +250,22 @@ public sealed class DeviceAgentRestClient : IMediaPiAgentClient
     {
         var json = JsonSerializer.Serialize(payload, SerializerOptions);
         return new StringContent(json, Encoding.UTF8, "application/json");
+    }
+
+    private static string ResolveSnapshotFilename(HttpResponseMessage response, string contentType)
+    {
+        var fromHeader = response.Content.Headers.ContentDisposition?.FileNameStar
+            ?? response.Content.Headers.ContentDisposition?.FileName;
+
+        if (!string.IsNullOrWhiteSpace(fromHeader))
+        {
+            return fromHeader.Trim('"');
+        }
+
+        var extension = ContentTypeProvider.Mappings
+            .FirstOrDefault(m => string.Equals(m.Value, contentType, StringComparison.OrdinalIgnoreCase))
+            .Key ?? ".jpg";
+        return $"snapshot_{DateTime.UtcNow:yyyy-MM-dd_HH-mm-ss}{extension}";
     }
 
     private Uri BuildUri(Device device, string path, string? query)

--- a/MediaPi.Core/Services/DeviceAgentRestClient.cs
+++ b/MediaPi.Core/Services/DeviceAgentRestClient.cs
@@ -269,6 +269,8 @@ public sealed class DeviceAgentRestClient : IMediaPiAgentClient
         return $"snapshot_{DateTime.UtcNow:yyyy-MM-dd_HH-mm-ss}{extension}";
     }
 
+    // Explicit chars ensure the set is safe cross-platform: Path.GetInvalidFileNameChars() on Linux
+    // only returns '\0' and '/'; the extras (|, <, >, *, ?, ", :, \) cover Windows-invalid chars too.
     private static readonly HashSet<char> UnsafeFileNameChars = new(
         Path.GetInvalidFileNameChars().Concat(new[] { '\\', '/', ':', '*', '?', '"', '<', '>', '|' }));
 

--- a/MediaPi.Core/Services/DeviceAgentRestClient.cs
+++ b/MediaPi.Core/Services/DeviceAgentRestClient.cs
@@ -105,11 +105,10 @@ public sealed class DeviceAgentRestClient : IMediaPiAgentClient
             throw new InvalidOperationException("Snapshot endpoint returned an empty response body.");
         }
 
-        var contentType = response.Content.Headers.ContentType?.MediaType;
-        if (string.IsNullOrWhiteSpace(contentType))
-        {
-            contentType = "image/jpeg";
-        }
+        var rawContentType = response.Content.Headers.ContentType?.MediaType;
+        var contentType = (!string.IsNullOrWhiteSpace(rawContentType) && rawContentType.StartsWith("image/", StringComparison.OrdinalIgnoreCase))
+            ? rawContentType
+            : "image/jpeg";
 
         var filename = ResolveSnapshotFilename(response, contentType);
         return new DeviceSnapshotResult
@@ -259,13 +258,28 @@ public sealed class DeviceAgentRestClient : IMediaPiAgentClient
 
         if (!string.IsNullOrWhiteSpace(fromHeader))
         {
-            return fromHeader.Trim('"');
+            var safe = NormalizeSafeFilename(fromHeader.Trim('"'));
+            if (!string.IsNullOrWhiteSpace(safe))
+                return safe;
         }
 
         var extension = ContentTypeProvider.Mappings
             .FirstOrDefault(m => string.Equals(m.Value, contentType, StringComparison.OrdinalIgnoreCase))
             .Key ?? ".jpg";
         return $"snapshot_{DateTime.UtcNow:yyyy-MM-dd_HH-mm-ss}{extension}";
+    }
+
+    private static readonly HashSet<char> UnsafeFileNameChars = new(
+        Path.GetInvalidFileNameChars().Concat(new[] { '\\', '/', ':', '*', '?', '"', '<', '>', '|' }));
+
+    private static string NormalizeSafeFilename(string input)
+    {
+        // Replace backslashes so Path.GetFileName also strips Windows-style path segments
+        var name = Path.GetFileName(input.Replace('\\', '/'));
+        var result = new System.Text.StringBuilder(name.Length);
+        foreach (var c in name)
+            result.Append(UnsafeFileNameChars.Contains(c) ? '_' : c);
+        return result.ToString().Trim();
     }
 
     private Uri BuildUri(Device device, string path, string? query)

--- a/MediaPi.Core/Services/DeviceAgentRestClient.cs
+++ b/MediaPi.Core/Services/DeviceAgentRestClient.cs
@@ -274,14 +274,24 @@ public sealed class DeviceAgentRestClient : IMediaPiAgentClient
     private static readonly HashSet<char> UnsafeFileNameChars = new(
         Path.GetInvalidFileNameChars().Concat(new[] { '\\', '/', ':', '*', '?', '"', '<', '>', '|' }));
 
+    private const int MaxSafeFilenameLength = 200;
+
     private static string NormalizeSafeFilename(string input)
     {
         // Replace backslashes so Path.GetFileName also strips Windows-style path segments
         var name = Path.GetFileName(input.Replace('\\', '/'));
         var result = new System.Text.StringBuilder(name.Length);
         foreach (var c in name)
-            result.Append(UnsafeFileNameChars.Contains(c) ? '_' : c);
-        return result.ToString().Trim();
+        {
+            if (char.IsControl(c) || UnsafeFileNameChars.Contains(c))
+                result.Append('_');
+            else
+                result.Append(c);
+        }
+        var normalized = result.ToString().Trim();
+        return normalized.Length > MaxSafeFilenameLength
+            ? normalized[..MaxSafeFilenameLength]
+            : normalized;
     }
 
     private Uri BuildUri(Device device, string path, string? query)

--- a/MediaPi.Core/Services/DeviceAgentRestClient.cs
+++ b/MediaPi.Core/Services/DeviceAgentRestClient.cs
@@ -289,9 +289,15 @@ public sealed class DeviceAgentRestClient : IMediaPiAgentClient
                 result.Append(c);
         }
         var normalized = result.ToString().Trim();
-        return normalized.Length > MaxSafeFilenameLength
-            ? normalized[..MaxSafeFilenameLength]
-            : normalized;
+        if (normalized.Length <= MaxSafeFilenameLength)
+            return normalized;
+
+        // Preserve the file extension when trimming to the length limit
+        var ext = Path.GetExtension(normalized);
+        var maxBase = MaxSafeFilenameLength - ext.Length;
+        return maxBase > 0
+            ? normalized[..maxBase] + ext
+            : normalized[..MaxSafeFilenameLength];
     }
 
     private Uri BuildUri(Device device, string path, string? query)

--- a/MediaPi.Core/Services/Interfaces/IMediaPiAgentClient.cs
+++ b/MediaPi.Core/Services/Interfaces/IMediaPiAgentClient.cs
@@ -8,6 +8,7 @@ namespace MediaPi.Core.Services.Interfaces;
 
 public interface IMediaPiAgentClient
 {
+    Task<DeviceSnapshotResult> CreateSnapshotAsync(Device device, CancellationToken cancellationToken = default);
     Task<MediaPiAgentListResponse> ListUnitsAsync(Device device, CancellationToken cancellationToken = default);
     Task<MediaPiAgentStatusResponse> GetStatusAsync(Device device, string unit, CancellationToken cancellationToken = default);
     Task<MediaPiAgentUnitResultResponse> StartUnitAsync(Device device, string unit, CancellationToken cancellationToken = default);
@@ -16,4 +17,11 @@ public interface IMediaPiAgentClient
     Task<MediaPiAgentEnableResponse> EnableUnitAsync(Device device, string unit, CancellationToken cancellationToken = default);
     Task<MediaPiAgentEnableResponse> DisableUnitAsync(Device device, string unit, CancellationToken cancellationToken = default);
     Task<MediaPiAgentHealthResponse> CheckHealthAsync(Device device, CancellationToken cancellationToken = default);
+}
+
+public sealed class DeviceSnapshotResult
+{
+    public required byte[] Content { get; init; }
+    public required string ContentType { get; init; }
+    public required string Filename { get; init; }
 }


### PR DESCRIPTION
### Motivation

- Add a device snapshot action so users who can manage devices can request a snapshot from the agent, persist it centrally and retrieve the file via the API.

### Description

- Introduced `IMediaPiAgentClient.CreateSnapshotAsync` and `DeviceSnapshotResult` to represent snapshot bytes, content type and filename. 
- Implemented `CreateSnapshotAsync` in `DeviceAgentRestClient` to call device `/api/snapshot`, validate response, infer filename/content type and return the payload. 
- Added `POST /api/devices/{id}/snapshot` (`CreateSnapshot`) to `DevicesController` which enforces manage-device permissions, calls the agent API, saves the returned image via `IScreenshotStorageService` and `Screenshot` model, then returns the image to the caller. 
- Added unit tests covering success, authorization and error scenarios and tests for the new agent client behavior. 

### Testing

- Built and ran the test suite with `dotnet build MediaPi.sln` and `dotnet test MediaPi.sln`, and collected coverage with `dotnet test MediaPi.Core.Tests/MediaPi.Core.Tests.csproj --collect:"XPlat Code Coverage"`. 
- All automated tests passed (`Passed: 660, Skipped: 3, Failed: 0`) and a coverage report (`coverage.cobertura.xml`) was produced. 
- New tests added: `DevicesControllerTests.CreateSnapshot_Admin_SavesScreenshotAndReturnsFile`, `DevicesControllerTests.CreateSnapshot_Manager_OwnDevice_Succeeds`, `DevicesControllerErrorTests.CreateSnapshot_EngineerAssignedDevice_ReturnsForbidden`, `DevicesControllerErrorTests.CreateSnapshot_AgentThrows_ReturnsBadGateway`, `DevicesControllerErrorTests.CreateSnapshot_StorageThrows_ReturnsBadGateway`, and `DeviceAgentRestClientTests.CreateSnapshotAsync_ReturnsImagePayload` which all passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de9a31bd588321b9f186af7bcb07a2)