### PR TITLE
fix: sanitize log entries created from user input

### DIFF
--- a/MediaPi.Core/Controllers/AuthController.cs
+++ b/MediaPi.Core/Controllers/AuthController.cs
@@ -80,11 +80,8 @@ public class AuthController(
     [ProducesResponseType(StatusCodes.Status401Unauthorized, Type = typeof(ErrMessage))]
     public async Task<ActionResult<UserViewItem>> Login(Credentials crd, CancellationToken ct = default)
     {
-        // Log the authentication attempt for security auditing
-        string sanitizedEmailForLog = (crd.Email ?? string.Empty)
-            .Replace("\r", string.Empty)
-            .Replace("\n", string.Empty);
-        _logger.LogDebug("Login attempt for {email}", sanitizedEmailForLog);
+        // Log the authentication attempt for security auditing without private identifiers
+        _logger.LogDebug("Login attempt received");
 
         // Query user with all necessary related data for complete authentication context
         // Include UserRoles and Role for permission checking
@@ -112,8 +109,8 @@ public class AuthController(
             Token = _jwtUtils.GenerateJwtToken(user),
         };
 
-        // Log successful authentication for security auditing
-        _logger.LogDebug("Login returning\n{res}", userViewItem.ToString());
+        // Log successful authentication for security auditing without sensitive payload data
+        _logger.LogDebug("Login successful");
         return userViewItem;
     }
 

--- a/MediaPi.Core/Controllers/AuthController.cs
+++ b/MediaPi.Core/Controllers/AuthController.cs
@@ -81,7 +81,10 @@ public class AuthController(
     public async Task<ActionResult<UserViewItem>> Login(Credentials crd, CancellationToken ct = default)
     {
         // Log the authentication attempt for security auditing
-        _logger.LogDebug("Login attempt for {email}", crd.Email);
+        string sanitizedEmailForLog = (crd.Email ?? string.Empty)
+            .Replace("\r", string.Empty)
+            .Replace("\n", string.Empty);
+        _logger.LogDebug("Login attempt for {email}", sanitizedEmailForLog);
 
         // Query user with all necessary related data for complete authentication context
         // Include UserRoles and Role for permission checking


### PR DESCRIPTION
Potential fix for [https://github.com/sw-consulting/media-pi.core/security/code-scanning/1](https://github.com/sw-consulting/media-pi.core/security/code-scanning/1)

General fix: sanitize user-controlled values before logging so control characters cannot alter log structure. For plain-text log safety, remove/neutralize `\r` and `\n` (and optionally trim).

Best minimal fix in this file: in `MediaPi.Core/Controllers/AuthController.cs`, inside `Login`, create a sanitized local variable from `crd.Email` and log that variable instead of raw input. This preserves functionality (still logs attempted email) while preventing log forging via line breaks. No new dependencies are needed; use standard `string.Replace`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
