### PR TITLE
Potential fix for code scanning alert no. 3: Log entries created from user input

### DIFF
--- a/MediaPi.Core/Controllers/DevicesController.cs
+++ b/MediaPi.Core/Controllers/DevicesController.cs
@@ -483,6 +483,14 @@ public partial class DevicesController(
         return (device, null);
     }
     
+    private static string? SanitizeForLog(string? value)
+    {
+        if (string.IsNullOrEmpty(value)) return value;
+
+        var sanitized = value.Replace("\r", "\\r").Replace("\n", "\\n");
+        return new string(sanitized.Select(ch => char.IsControl(ch) ? '?' : ch).ToArray());
+    }
+
     private async Task<ActionResult<TResponse>> ExecuteAgentOperation<TResponse>(
         int id,
         string operationName,
@@ -495,9 +503,7 @@ public partial class DevicesController(
         if (error != null) return error;
 
         var targetDevice = device!;
-        var safeUnitForLog = string.IsNullOrEmpty(unit)
-            ? unit
-            : unit.Replace("\r", "\\r").Replace("\n", "\\n");
+        var safeUnitForLog = SanitizeForLog(unit);
 
         try
         {

--- a/MediaPi.Core/Controllers/DevicesController.cs
+++ b/MediaPi.Core/Controllers/DevicesController.cs
@@ -495,6 +495,9 @@ public partial class DevicesController(
         if (error != null) return error;
 
         var targetDevice = device!;
+        var safeUnitForLog = string.IsNullOrEmpty(unit)
+            ? unit
+            : unit.Replace("\r", "\\r").Replace("\n", "\\n");
 
         try
         {
@@ -507,7 +510,7 @@ public partial class DevicesController(
                 }
                 else
                 {
-                    logger.LogWarning("Агент не выполнил операцию {Operation} для устройства {DeviceId}, сервиса {Unit}: {Error}", operationName, id, unit, response.ErrMsg ?? "неизвестная ошибка");
+                    logger.LogWarning("Агент не выполнил операцию {Operation} для устройства {DeviceId}, сервиса {Unit}: {Error}", operationName, id, safeUnitForLog, response.ErrMsg ?? "неизвестная ошибка");
                 }
                 return _502Agent(response.ErrMsg);
             }
@@ -522,7 +525,7 @@ public partial class DevicesController(
             }
             else
             {
-                logger.LogError(ex, "Ошибка при выполнении операции {Operation} для устройства {DeviceId}, сервиса {Unit}", operationName, id, unit);
+                logger.LogError(ex, "Ошибка при выполнении операции {Operation} для устройства {DeviceId}, сервиса {Unit}", operationName, id, safeUnitForLog);
             }
 
             return _502Agent();

--- a/MediaPi.Core/Controllers/DevicesController.cs
+++ b/MediaPi.Core/Controllers/DevicesController.cs
@@ -318,7 +318,7 @@ public partial class DevicesController(
     public async Task<ActionResult<MediaPiAgentUnitResultResponse>> StartService(int id, string unit, CancellationToken ct = default)
     {
         if (string.IsNullOrWhiteSpace(unit)) return _400ServiceUnit(unit);
-        var service = unit.Trim();
+        var service = unit.Trim().Replace("\r", "").Replace("\n", "");
         return await ExecuteAgentOperation(
             id,
             "start service",
@@ -337,7 +337,7 @@ public partial class DevicesController(
     public async Task<ActionResult<MediaPiAgentUnitResultResponse>> StopService(int id, string unit, CancellationToken ct = default)
     {
         if (string.IsNullOrWhiteSpace(unit)) return _400ServiceUnit(unit);
-        var service = unit.Trim();
+        var service = unit.Trim().Replace("\r", "").Replace("\n", "");
         return await ExecuteAgentOperation(
             id,
             "stop service",
@@ -356,7 +356,7 @@ public partial class DevicesController(
     public async Task<ActionResult<MediaPiAgentUnitResultResponse>> RestartService(int id, string unit, CancellationToken ct = default)
     {
         if (string.IsNullOrWhiteSpace(unit)) return _400ServiceUnit(unit);
-        var service = unit.Trim();
+        var service = unit.Trim().Replace("\r", "").Replace("\n", "");
         return await ExecuteAgentOperation(
             id,
             "restart service",
@@ -375,7 +375,7 @@ public partial class DevicesController(
     public async Task<ActionResult<MediaPiAgentEnableResponse>> EnableService(int id, string unit, CancellationToken ct = default)
     {
         if (string.IsNullOrWhiteSpace(unit)) return _400ServiceUnit(unit);
-        var service = unit.Trim();
+        var service = unit.Trim().Replace("\r", "").Replace("\n", "");
         return await ExecuteAgentOperation(
             id,
             "enable service",
@@ -394,7 +394,7 @@ public partial class DevicesController(
     public async Task<ActionResult<MediaPiAgentEnableResponse>> DisableService(int id, string unit, CancellationToken ct = default)
     {
         if (string.IsNullOrWhiteSpace(unit)) return _400ServiceUnit(unit);
-        var service = unit.Trim();
+        var service = unit.Trim().Replace("\r", "").Replace("\n", "");
         return await ExecuteAgentOperation(
             id,
             "disable service",


### PR DESCRIPTION
Potential fix for [https://github.com/sw-consulting/media-pi.core/security/code-scanning/3](https://github.com/sw-consulting/media-pi.core/security/code-scanning/3)

The best fix is to sanitize the user-controlled `unit` value before it reaches logging, while preserving existing behavior for service operations.  
A single, minimal, and robust approach here is to sanitize `unit` inside `ExecuteAgentOperation` right before logging, replacing CR/LF with safe characters (or spaces) and optionally trimming. This addresses all 5 variants at one sink point, without changing endpoint logic or agent calls.

Concretely in `MediaPi.Core/Controllers/DevicesController.cs`:
1. In `ExecuteAgentOperation<TResponse>(...)`, after `var targetDevice = device!;`, create a local `safeUnitForLog` derived from `unit` with `\r` and `\n` removed/replaced.
2. Use `safeUnitForLog` instead of `unit` in both log statements that include `{Unit}` (warning and error).
3. No new dependency is required; use `string.Replace`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
