### PR TITLE
Subscriptions and categories 3

### DIFF
--- a/MediaPi.Core.Tests/Controllers/AccountsControllerTests.cs
+++ b/MediaPi.Core.Tests/Controllers/AccountsControllerTests.cs
@@ -7,6 +7,7 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using Moq;
 using NUnit.Framework;
+using System;
 using System.Linq;
 using System.Threading.Tasks;
 using MediaPi.Core.Controllers;
@@ -14,6 +15,7 @@ using MediaPi.Core.Data;
 using MediaPi.Core.Models;
 using MediaPi.Core.RestModels;
 using MediaPi.Core.Services;
+using MediaPi.Core.Tests.TestHelpers;
 
 namespace MediaPi.Core.Tests.Controllers;
 
@@ -104,6 +106,8 @@ public class AccountsControllerTests
         _controller = new AccountsController(
             _mockHttpContextAccessor.Object,
             _userInformationService,
+            SubscriptionTestServices.PlaylistAccessService(_dbContext),
+            SubscriptionTestServices.TimeService(),
             _dbContext,
             _mockLogger.Object)
         {
@@ -203,6 +207,330 @@ public class AccountsControllerTests
         var acc = await _dbContext.Accounts.FindAsync(_account1.Id);
         Assert.That(acc, Is.Null);
     }
+
+    [Test]
+    public async Task GetSubscriptions_ReturnsOnlyPaidCategories()
+    {
+        var paidCategory = new Category { Title = "Paid", Free = false };
+        var freeCategory = new Category { Title = "Free", Free = true };
+        var availablePaidCategory = new Category { Title = "Available Paid", Free = false };
+        var availableFreeCategory = new Category { Title = "Available Free", Free = true };
+        _dbContext.Categories.AddRange(paidCategory, freeCategory, availablePaidCategory, availableFreeCategory);
+        await _dbContext.SaveChangesAsync();
+
+        _dbContext.Subscriptions.AddRange(
+            new Subscription
+            {
+                AccountId = _account1.Id,
+                CategoryId = paidCategory.Id,
+                StartTime = new DateTime(2026, 6, 1, 0, 0, 0, DateTimeKind.Utc),
+                EndTime = new DateTime(2026, 6, 30, 23, 59, 59, DateTimeKind.Utc)
+            },
+            new Subscription
+            {
+                AccountId = _account1.Id,
+                CategoryId = freeCategory.Id,
+                StartTime = new DateTime(2026, 6, 1, 0, 0, 0, DateTimeKind.Utc),
+                EndTime = new DateTime(2026, 6, 30, 23, 59, 59, DateTimeKind.Utc)
+            });
+        await _dbContext.SaveChangesAsync();
+
+        SetCurrentUser(1);
+        var result = await _controller.GetSubscriptions(_account1.Id);
+
+        Assert.That(result.Value, Is.Not.Null);
+        Assert.That(result.Value!.Subscriptions.Select(s => s.CategoryTitle), Is.EquivalentTo(new[] { "Paid" }));
+        Assert.That(result.Value.AvailableCategories.Select(c => c.Title), Is.EquivalentTo(new[] { "Available Paid" }));
+    }
+
+    [Test]
+    public async Task UpsertSubscription_FreeCategory_Returns400()
+    {
+        var freeCategory = new Category { Title = "Free", Free = true };
+        _dbContext.Categories.Add(freeCategory);
+        await _dbContext.SaveChangesAsync();
+
+        SetCurrentUser(1);
+        var result = await _controller.UpsertSubscription(
+            _account1.Id,
+            freeCategory.Id,
+            new SubscriptionUpsertItem
+            {
+                StartDate = new DateOnly(2026, 6, 1),
+                EndDate = new DateOnly(2026, 6, 30)
+            });
+
+        Assert.That(result, Is.TypeOf<ObjectResult>());
+        var objectResult = result as ObjectResult;
+        Assert.That(objectResult!.StatusCode, Is.EqualTo(StatusCodes.Status400BadRequest));
+        Assert.That(_dbContext.Subscriptions.Any(s => s.CategoryId == freeCategory.Id), Is.False);
+    }
+
+    #region UpsertSubscription and GetSubscriptions Additional Tests
+
+    [Test]
+    public async Task UpsertSubscription_NoUser_Returns403()
+    {
+        SetCurrentUser(null);
+        var paidCategory = new Category { Title = "Paid2", Free = false };
+        _dbContext.Categories.Add(paidCategory);
+        await _dbContext.SaveChangesAsync();
+
+        var result = await _controller.UpsertSubscription(
+            _account1.Id,
+            paidCategory.Id,
+            new SubscriptionUpsertItem { StartDate = new DateOnly(2026, 6, 1), EndDate = new DateOnly(2026, 6, 30) });
+
+        Assert.That(result, Is.TypeOf<ObjectResult>());
+        Assert.That(((ObjectResult)result).StatusCode, Is.EqualTo(StatusCodes.Status403Forbidden));
+    }
+
+    [Test]
+    public async Task UpsertSubscription_NonAdmin_Returns403()
+    {
+        SetCurrentUser(2); // Manager
+        var paidCategory = new Category { Title = "Paid3", Free = false };
+        _dbContext.Categories.Add(paidCategory);
+        await _dbContext.SaveChangesAsync();
+
+        var result = await _controller.UpsertSubscription(
+            _account1.Id,
+            paidCategory.Id,
+            new SubscriptionUpsertItem { StartDate = new DateOnly(2026, 6, 1), EndDate = new DateOnly(2026, 6, 30) });
+
+        Assert.That(result, Is.TypeOf<ObjectResult>());
+        Assert.That(((ObjectResult)result).StatusCode, Is.EqualTo(StatusCodes.Status403Forbidden));
+    }
+
+    [Test]
+    public async Task UpsertSubscription_InvalidDateRange_Returns400()
+    {
+        SetCurrentUser(1);
+        var paidCategory = new Category { Title = "Paid4", Free = false };
+        _dbContext.Categories.Add(paidCategory);
+        await _dbContext.SaveChangesAsync();
+
+        var result = await _controller.UpsertSubscription(
+            _account1.Id,
+            paidCategory.Id,
+            new SubscriptionUpsertItem
+            {
+                StartDate = new DateOnly(2026, 6, 30),
+                EndDate = new DateOnly(2026, 6, 1)  // end < start
+            });
+
+        Assert.That(result, Is.TypeOf<ObjectResult>());
+        Assert.That(((ObjectResult)result).StatusCode, Is.EqualTo(StatusCodes.Status400BadRequest));
+    }
+
+    [Test]
+    public async Task UpsertSubscription_AccountNotFound_Returns404()
+    {
+        SetCurrentUser(1);
+        var paidCategory = new Category { Title = "Paid5", Free = false };
+        _dbContext.Categories.Add(paidCategory);
+        await _dbContext.SaveChangesAsync();
+
+        var result = await _controller.UpsertSubscription(
+            9999,
+            paidCategory.Id,
+            new SubscriptionUpsertItem { StartDate = new DateOnly(2026, 6, 1), EndDate = new DateOnly(2026, 6, 30) });
+
+        Assert.That(result, Is.TypeOf<ObjectResult>());
+        Assert.That(((ObjectResult)result).StatusCode, Is.EqualTo(StatusCodes.Status404NotFound));
+    }
+
+    [Test]
+    public async Task UpsertSubscription_CategoryNotFound_Returns404()
+    {
+        SetCurrentUser(1);
+
+        var result = await _controller.UpsertSubscription(
+            _account1.Id,
+            9999,
+            new SubscriptionUpsertItem { StartDate = new DateOnly(2026, 6, 1), EndDate = new DateOnly(2026, 6, 30) });
+
+        Assert.That(result, Is.TypeOf<ObjectResult>());
+        Assert.That(((ObjectResult)result).StatusCode, Is.EqualTo(StatusCodes.Status404NotFound));
+    }
+
+    [Test]
+    public async Task UpsertSubscription_NewSubscription_CreatesRecord()
+    {
+        SetCurrentUser(1);
+        var paidCategory = new Category { Title = "Paid6", Free = false };
+        _dbContext.Categories.Add(paidCategory);
+        await _dbContext.SaveChangesAsync();
+
+        var result = await _controller.UpsertSubscription(
+            _account1.Id,
+            paidCategory.Id,
+            new SubscriptionUpsertItem { StartDate = new DateOnly(2026, 6, 1), EndDate = new DateOnly(2026, 6, 30) });
+
+        Assert.That(result, Is.TypeOf<NoContentResult>());
+        Assert.That(_dbContext.Subscriptions.Any(s => s.AccountId == _account1.Id && s.CategoryId == paidCategory.Id), Is.True);
+    }
+
+    [Test]
+    public async Task UpsertSubscription_ExistingSubscription_UpdatesDates()
+    {
+        var paidCategory = new Category { Title = "Paid7", Free = false };
+        _dbContext.Categories.Add(paidCategory);
+        await _dbContext.SaveChangesAsync();
+
+        _dbContext.Subscriptions.Add(new Subscription
+        {
+            AccountId = _account1.Id,
+            CategoryId = paidCategory.Id,
+            StartTime = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+            EndTime = new DateTime(2026, 1, 31, 23, 59, 59, DateTimeKind.Utc)
+        });
+        await _dbContext.SaveChangesAsync();
+
+        SetCurrentUser(1);
+        var result = await _controller.UpsertSubscription(
+            _account1.Id,
+            paidCategory.Id,
+            new SubscriptionUpsertItem { StartDate = new DateOnly(2026, 6, 1), EndDate = new DateOnly(2026, 6, 30) });
+
+        Assert.That(result, Is.TypeOf<NoContentResult>());
+        var sub = _dbContext.Subscriptions.Single(s => s.AccountId == _account1.Id && s.CategoryId == paidCategory.Id);
+        // The start/end are converted from local dates; just verify it was saved
+        Assert.That(sub.StartTime.Year, Is.EqualTo(2026));
+    }
+
+    [Test]
+    public async Task UpsertSubscription_WithImpactNoForce_Returns409()
+    {
+        // Setup: paid video in playlist (no active subscription → will have impact when subscription becomes inactive)
+        var paidCategory = new Category { Title = "Paid8", Free = false };
+        _dbContext.Categories.Add(paidCategory);
+        var commonVideo = new Video
+        {
+            Id = 501,
+            Title = "Common501",
+            Filename = "v501.mp4",
+            OriginalFilename = "v501.mp4",
+            FileSizeBytes = 100,
+            CategoryId = null,   // will be set after save
+            Sha256 = new string('b', 64)
+        };
+        _dbContext.Videos.Add(commonVideo);
+        await _dbContext.SaveChangesAsync();
+
+        commonVideo.CategoryId = paidCategory.Id;
+        var playlist = new Playlist { Id = 501, Title = "Playlist501", Filename = "p501.m3u", AccountId = _account1.Id, Account = _account1 };
+        _dbContext.Playlists.Add(playlist);
+        _dbContext.VideoPlaylists.Add(new VideoPlaylist
+        {
+            Id = 5010,
+            PlaylistId = playlist.Id,
+            Playlist = playlist,
+            VideoId = commonVideo.Id,
+            Video = commonVideo,
+            Position = 0
+        });
+        await _dbContext.SaveChangesAsync();
+
+        SetCurrentUser(1);
+        // Propose subscription ending in the past → becomes inactive → has impact
+        var result = await _controller.UpsertSubscription(
+            _account1.Id,
+            paidCategory.Id,
+            new SubscriptionUpsertItem
+            {
+                StartDate = new DateOnly(2026, 1, 1),
+                EndDate = new DateOnly(2026, 1, 31),
+                ForcePlaylistCleanup = false
+            });
+
+        Assert.That(result, Is.TypeOf<ObjectResult>());
+        Assert.That(((ObjectResult)result).StatusCode, Is.EqualTo(StatusCodes.Status409Conflict));
+    }
+
+    [Test]
+    public async Task UpsertSubscription_WithImpactForce_RemovesItems()
+    {
+        var paidCategory = new Category { Title = "Paid9", Free = false };
+        _dbContext.Categories.Add(paidCategory);
+        var commonVideo = new Video
+        {
+            Id = 502,
+            Title = "Common502",
+            Filename = "v502.mp4",
+            OriginalFilename = "v502.mp4",
+            FileSizeBytes = 100,
+            Sha256 = new string('c', 64)
+        };
+        _dbContext.Videos.Add(commonVideo);
+        await _dbContext.SaveChangesAsync();
+
+        commonVideo.CategoryId = paidCategory.Id;
+        var playlist = new Playlist { Id = 502, Title = "Playlist502", Filename = "p502.m3u", AccountId = _account1.Id, Account = _account1 };
+        _dbContext.Playlists.Add(playlist);
+        _dbContext.VideoPlaylists.Add(new VideoPlaylist
+        {
+            Id = 5020,
+            PlaylistId = playlist.Id,
+            Playlist = playlist,
+            VideoId = commonVideo.Id,
+            Video = commonVideo,
+            Position = 0
+        });
+        await _dbContext.SaveChangesAsync();
+
+        SetCurrentUser(1);
+        // Force cleanup with a subscription that expires in the past
+        var result = await _controller.UpsertSubscription(
+            _account1.Id,
+            paidCategory.Id,
+            new SubscriptionUpsertItem
+            {
+                StartDate = new DateOnly(2026, 1, 1),
+                EndDate = new DateOnly(2026, 1, 31),
+                ForcePlaylistCleanup = true
+            });
+
+        Assert.That(result, Is.TypeOf<NoContentResult>());
+        Assert.That(_dbContext.VideoPlaylists.Any(vp => vp.Id == 5020), Is.False);
+    }
+
+    [Test]
+    public async Task GetSubscriptions_ManagerOwnsAccount_Returns200()
+    {
+        SetCurrentUser(2); // Manager linked to account1
+        var result = await _controller.GetSubscriptions(_account1.Id);
+        Assert.That(result.Value, Is.Not.Null);
+    }
+
+    [Test]
+    public async Task GetSubscriptions_ManagerOtherAccount_Returns403()
+    {
+        SetCurrentUser(2); // Manager NOT linked to account2
+        var result = await _controller.GetSubscriptions(_account2.Id);
+        Assert.That(result.Result, Is.TypeOf<ObjectResult>());
+        Assert.That(((ObjectResult)result.Result!).StatusCode, Is.EqualTo(StatusCodes.Status403Forbidden));
+    }
+
+    [Test]
+    public async Task GetSubscriptions_AccountNotFound_Returns404()
+    {
+        SetCurrentUser(1);
+        var result = await _controller.GetSubscriptions(9999);
+        Assert.That(result.Result, Is.TypeOf<ObjectResult>());
+        Assert.That(((ObjectResult)result.Result!).StatusCode, Is.EqualTo(StatusCodes.Status404NotFound));
+    }
+
+    [Test]
+    public async Task GetSubscriptions_NoUser_Returns403()
+    {
+        SetCurrentUser(null);
+        var result = await _controller.GetSubscriptions(_account1.Id);
+        Assert.That(result.Result, Is.TypeOf<ObjectResult>());
+        Assert.That(((ObjectResult)result.Result!).StatusCode, Is.EqualTo(StatusCodes.Status403Forbidden));
+    }
+
+    #endregion
 
     #region UpdateAccount Tests
 

--- a/MediaPi.Core.Tests/Controllers/AccountsControllerTests.cs
+++ b/MediaPi.Core.Tests/Controllers/AccountsControllerTests.cs
@@ -530,6 +530,189 @@ public class AccountsControllerTests
         Assert.That(((ObjectResult)result.Result!).StatusCode, Is.EqualTo(StatusCodes.Status403Forbidden));
     }
 
+    [Test]
+    public async Task DeleteSubscription_NoUser_Returns403()
+    {
+        var paidCategory = new Category { Title = "Delete Paid", Free = false };
+        _dbContext.Categories.Add(paidCategory);
+        await _dbContext.SaveChangesAsync();
+
+        SetCurrentUser(null);
+        var result = await _controller.DeleteSubscription(_account1.Id, paidCategory.Id);
+
+        Assert.That(result, Is.TypeOf<ObjectResult>());
+        Assert.That(((ObjectResult)result).StatusCode, Is.EqualTo(StatusCodes.Status403Forbidden));
+    }
+
+    [Test]
+    public async Task DeleteSubscription_NonAdmin_Returns403()
+    {
+        var paidCategory = new Category { Title = "Delete Paid Manager", Free = false };
+        _dbContext.Categories.Add(paidCategory);
+        await _dbContext.SaveChangesAsync();
+
+        SetCurrentUser(2);
+        var result = await _controller.DeleteSubscription(_account1.Id, paidCategory.Id);
+
+        Assert.That(result, Is.TypeOf<ObjectResult>());
+        Assert.That(((ObjectResult)result).StatusCode, Is.EqualTo(StatusCodes.Status403Forbidden));
+    }
+
+    [Test]
+    public async Task DeleteSubscription_AccountNotFound_Returns404()
+    {
+        var paidCategory = new Category { Title = "Delete Paid Account Missing", Free = false };
+        _dbContext.Categories.Add(paidCategory);
+        await _dbContext.SaveChangesAsync();
+
+        SetCurrentUser(1);
+        var result = await _controller.DeleteSubscription(9999, paidCategory.Id);
+
+        Assert.That(result, Is.TypeOf<ObjectResult>());
+        Assert.That(((ObjectResult)result).StatusCode, Is.EqualTo(StatusCodes.Status404NotFound));
+    }
+
+    [Test]
+    public async Task DeleteSubscription_CategoryNotFound_Returns404()
+    {
+        SetCurrentUser(1);
+        var result = await _controller.DeleteSubscription(_account1.Id, 9999);
+
+        Assert.That(result, Is.TypeOf<ObjectResult>());
+        Assert.That(((ObjectResult)result).StatusCode, Is.EqualTo(StatusCodes.Status404NotFound));
+    }
+
+    [Test]
+    public async Task DeleteSubscription_NoExistingSubscription_ReturnsNoContent()
+    {
+        var paidCategory = new Category { Title = "Delete Paid Empty", Free = false };
+        _dbContext.Categories.Add(paidCategory);
+        await _dbContext.SaveChangesAsync();
+
+        SetCurrentUser(1);
+        var result = await _controller.DeleteSubscription(_account1.Id, paidCategory.Id);
+
+        Assert.That(result, Is.TypeOf<NoContentResult>());
+    }
+
+    [Test]
+    public async Task DeleteSubscription_ExistingSubscription_RemovesRecord()
+    {
+        var paidCategory = new Category { Title = "Delete Paid Existing", Free = false };
+        _dbContext.Categories.Add(paidCategory);
+        await _dbContext.SaveChangesAsync();
+        _dbContext.Subscriptions.Add(new Subscription
+        {
+            AccountId = _account1.Id,
+            CategoryId = paidCategory.Id,
+            StartTime = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+            EndTime = new DateTime(2026, 12, 31, 23, 59, 59, DateTimeKind.Utc)
+        });
+        await _dbContext.SaveChangesAsync();
+
+        SetCurrentUser(1);
+        var result = await _controller.DeleteSubscription(_account1.Id, paidCategory.Id);
+
+        Assert.That(result, Is.TypeOf<NoContentResult>());
+        Assert.That(_dbContext.Subscriptions.Any(s => s.AccountId == _account1.Id && s.CategoryId == paidCategory.Id), Is.False);
+    }
+
+    [Test]
+    public async Task DeleteSubscription_WithImpactNoForce_Returns409()
+    {
+        var paidCategory = new Category { Title = "Delete Paid Impact", Free = false };
+        _dbContext.Categories.Add(paidCategory);
+        var commonVideo = new Video
+        {
+            Id = 503,
+            Title = "Common503",
+            Filename = "v503.mp4",
+            OriginalFilename = "v503.mp4",
+            FileSizeBytes = 100,
+            Sha256 = new string('d', 64)
+        };
+        _dbContext.Videos.Add(commonVideo);
+        await _dbContext.SaveChangesAsync();
+
+        commonVideo.CategoryId = paidCategory.Id;
+        _dbContext.Subscriptions.Add(new Subscription
+        {
+            AccountId = _account1.Id,
+            CategoryId = paidCategory.Id,
+            StartTime = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+            EndTime = new DateTime(2026, 12, 31, 23, 59, 59, DateTimeKind.Utc)
+        });
+        var playlist = new Playlist { Id = 503, Title = "Playlist503", Filename = "p503.m3u", AccountId = _account1.Id, Account = _account1 };
+        _dbContext.Playlists.Add(playlist);
+        _dbContext.VideoPlaylists.Add(new VideoPlaylist
+        {
+            Id = 5030,
+            PlaylistId = playlist.Id,
+            Playlist = playlist,
+            VideoId = commonVideo.Id,
+            Video = commonVideo,
+            Position = 0
+        });
+        await _dbContext.SaveChangesAsync();
+
+        SetCurrentUser(1);
+        var result = await _controller.DeleteSubscription(_account1.Id, paidCategory.Id);
+
+        Assert.That(result, Is.TypeOf<ObjectResult>());
+        Assert.That(((ObjectResult)result).StatusCode, Is.EqualTo(StatusCodes.Status409Conflict));
+        Assert.That(_dbContext.Subscriptions.Any(s => s.AccountId == _account1.Id && s.CategoryId == paidCategory.Id), Is.True);
+        Assert.That(_dbContext.VideoPlaylists.Any(vp => vp.Id == 5030), Is.True);
+    }
+
+    [Test]
+    public async Task DeleteSubscription_WithImpactForce_RemovesItemsAndSubscription()
+    {
+        var paidCategory = new Category { Title = "Delete Paid Force", Free = false };
+        _dbContext.Categories.Add(paidCategory);
+        var commonVideo = new Video
+        {
+            Id = 504,
+            Title = "Common504",
+            Filename = "v504.mp4",
+            OriginalFilename = "v504.mp4",
+            FileSizeBytes = 100,
+            Sha256 = new string('e', 64)
+        };
+        _dbContext.Videos.Add(commonVideo);
+        await _dbContext.SaveChangesAsync();
+
+        commonVideo.CategoryId = paidCategory.Id;
+        _dbContext.Subscriptions.Add(new Subscription
+        {
+            AccountId = _account1.Id,
+            CategoryId = paidCategory.Id,
+            StartTime = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+            EndTime = new DateTime(2026, 12, 31, 23, 59, 59, DateTimeKind.Utc)
+        });
+        var playlist = new Playlist { Id = 504, Title = "Playlist504", Filename = "p504.m3u", AccountId = _account1.Id, Account = _account1 };
+        _dbContext.Playlists.Add(playlist);
+        _dbContext.VideoPlaylists.Add(new VideoPlaylist
+        {
+            Id = 5040,
+            PlaylistId = playlist.Id,
+            Playlist = playlist,
+            VideoId = commonVideo.Id,
+            Video = commonVideo,
+            Position = 0
+        });
+        await _dbContext.SaveChangesAsync();
+
+        SetCurrentUser(1);
+        var result = await _controller.DeleteSubscription(
+            _account1.Id,
+            paidCategory.Id,
+            new SubscriptionDeleteItem { ForcePlaylistCleanup = true });
+
+        Assert.That(result, Is.TypeOf<NoContentResult>());
+        Assert.That(_dbContext.Subscriptions.Any(s => s.AccountId == _account1.Id && s.CategoryId == paidCategory.Id), Is.False);
+        Assert.That(_dbContext.VideoPlaylists.Any(vp => vp.Id == 5040), Is.False);
+    }
+
     #endregion
 
     #region UpdateAccount Tests

--- a/MediaPi.Core.Tests/Controllers/CategoriesControllerTests.cs
+++ b/MediaPi.Core.Tests/Controllers/CategoriesControllerTests.cs
@@ -5,6 +5,7 @@ using MediaPi.Core.Controllers;
 using MediaPi.Core.Data;
 using MediaPi.Core.Models;
 using MediaPi.Core.RestModels;
+using MediaPi.Core.Tests.TestHelpers;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
@@ -85,6 +86,7 @@ public class CategoriesControllerTests
         _mockHttpContextAccessor.Setup(x => x.HttpContext).Returns(context);
         _controller = new CategoriesController(
             _mockHttpContextAccessor.Object,
+            SubscriptionTestServices.PlaylistAccessService(_dbContext),
             _dbContext,
             _mockLogger.Object)
         {
@@ -228,6 +230,81 @@ public class CategoriesControllerTests
         var updated = await _dbContext.Categories.FindAsync(_category1.Id);
         Assert.That(updated!.Title, Is.EqualTo("Cinema"));
         Assert.That(updated.Free, Is.False);
+    }
+
+    [Test]
+    public async Task UpdateCategory_FreeToPaidWithPlaylistImpact_Returns409WithAffectedPlaylists()
+    {
+        SetCurrentUser(1);
+        var account = new Account { Id = 10, Name = "Account" };
+        var video = new Video
+        {
+            Id = 10,
+            Title = "Common",
+            Filename = "common.mp4",
+            OriginalFilename = "common.mp4",
+            FileSizeBytes = 100,
+            CategoryId = _category1.Id,
+            Category = _category1
+        };
+        var playlist = new Playlist { Id = 10, Title = "Playlist", Filename = "playlist.m3u", AccountId = account.Id, Account = account };
+        _dbContext.Accounts.Add(account);
+        _dbContext.Videos.Add(video);
+        _dbContext.Playlists.Add(playlist);
+        _dbContext.VideoPlaylists.Add(new VideoPlaylist
+        {
+            Id = 10,
+            VideoId = video.Id,
+            Video = video,
+            PlaylistId = playlist.Id,
+            Playlist = playlist,
+            Position = 0
+        });
+        await _dbContext.SaveChangesAsync();
+
+        var result = await _controller.UpdateCategory(_category1.Id, new CategoryUpdateItem { Free = false });
+
+        AssertObjectStatus(result, StatusCodes.Status409Conflict);
+        var impact = (PlaylistAccessImpact)((ObjectResult)result).Value!;
+        Assert.That(impact.AffectedPlaylistCount, Is.EqualTo(1));
+        Assert.That(impact.AffectedPlaylists.Single().Title, Is.EqualTo("Playlist"));
+    }
+
+    [Test]
+    public async Task UpdateCategory_ForcePlaylistCleanup_RemovesInvalidRows()
+    {
+        SetCurrentUser(1);
+        var account = new Account { Id = 11, Name = "Account" };
+        var video = new Video
+        {
+            Id = 11,
+            Title = "Common",
+            Filename = "common2.mp4",
+            OriginalFilename = "common2.mp4",
+            FileSizeBytes = 100,
+            CategoryId = _category1.Id,
+            Category = _category1
+        };
+        var playlist = new Playlist { Id = 11, Title = "Playlist", Filename = "playlist2.m3u", AccountId = account.Id, Account = account };
+        _dbContext.Accounts.Add(account);
+        _dbContext.Videos.Add(video);
+        _dbContext.Playlists.Add(playlist);
+        _dbContext.VideoPlaylists.Add(new VideoPlaylist
+        {
+            Id = 11,
+            VideoId = video.Id,
+            Video = video,
+            PlaylistId = playlist.Id,
+            Playlist = playlist,
+            Position = 0
+        });
+        await _dbContext.SaveChangesAsync();
+
+        var result = await _controller.UpdateCategory(_category1.Id, new CategoryUpdateItem { Free = false, ForcePlaylistCleanup = true });
+
+        Assert.That(result, Is.TypeOf<NoContentResult>());
+        Assert.That((await _dbContext.Categories.FindAsync(_category1.Id))!.Free, Is.False);
+        Assert.That(await _dbContext.VideoPlaylists.AnyAsync(vp => vp.Id == 11), Is.False);
     }
 
     [Test]

--- a/MediaPi.Core.Tests/Controllers/DeviceSyncControllerTests.cs
+++ b/MediaPi.Core.Tests/Controllers/DeviceSyncControllerTests.cs
@@ -12,6 +12,7 @@ using MediaPi.Core.Data;
 using MediaPi.Core.Models;
 using MediaPi.Core.RestModels;
 using MediaPi.Core.Services.Interfaces;
+using MediaPi.Core.Tests.TestHelpers;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
@@ -79,6 +80,7 @@ public class DeviceSyncControllerTests
             _mockHttpContextAccessor.Object,
             _mockVideoStorageService.Object,
             _mockScreenshotStorageService.Object,
+            SubscriptionTestServices.PlaylistAccessService(_dbContext),
             _dbContext,
             _mockLogger.Object)
         {
@@ -118,6 +120,38 @@ public class DeviceSyncControllerTests
         Assert.That(video1Item.Filename, Is.EqualTo(video1.Filename));
         Assert.That(video1Item.FileSizeBytes, Is.EqualTo(video1.FileSizeBytes));
         Assert.That(video1Item.Sha256, Is.EqualTo(video1.Sha256));
+    }
+
+    [Test]
+    public async Task GetManifest_ExcludesCommonPaidCategoryWithoutSubscription()
+    {
+        var category = new Category { Id = 10, Title = "Paid", Free = false };
+        var playlist = new Playlist { Id = 30, Title = "Playlist", Filename = "playlist30.json", AccountId = _account.Id, Account = _account };
+        var video = new Video
+        {
+            Id = 300,
+            Title = "Premium",
+            Filename = "0001/premium.mp4",
+            OriginalFilename = "premium.mp4",
+            FileSizeBytes = 1024,
+            CategoryId = category.Id,
+            Category = category,
+            Sha256 = "abc"
+        };
+
+        _dbContext.Categories.Add(category);
+        _dbContext.Playlists.Add(playlist);
+        _dbContext.Videos.Add(video);
+        _dbContext.VideoPlaylists.Add(new VideoPlaylist { VideoId = video.Id, Video = video, PlaylistId = playlist.Id, Playlist = playlist });
+        _dbContext.PlaylistDeviceGroups.Add(new PlaylistDeviceGroup { PlaylistId = playlist.Id, Playlist = playlist, DeviceGroupId = _deviceGroup.Id, DeviceGroup = _deviceGroup });
+        _dbContext.SaveChanges();
+
+        SetDeviceContext(_device.Id);
+
+        var result = await _controller.GetManifest();
+
+        Assert.That(result.Value, Is.Not.Null);
+        Assert.That(result.Value!, Is.Empty);
     }
 
     [Test]

--- a/MediaPi.Core.Tests/Controllers/PlaylistsControllerEmptyPlaylistTests.cs
+++ b/MediaPi.Core.Tests/Controllers/PlaylistsControllerEmptyPlaylistTests.cs
@@ -15,6 +15,7 @@ using MediaPi.Core.Data;
 using MediaPi.Core.Models;
 using MediaPi.Core.RestModels;
 using MediaPi.Core.Services;
+using MediaPi.Core.Tests.TestHelpers;
 
 namespace MediaPi.Core.Tests.Controllers;
 
@@ -73,6 +74,7 @@ public class PlaylistsControllerEmptyPlaylistTests
         _controller = new PlaylistsController(
             _mockHttpContextAccessor.Object,
             _userInformationService,
+            SubscriptionTestServices.PlaylistAccessService(_dbContext),
             _dbContext,
             _mockLogger.Object)
         {

--- a/MediaPi.Core.Tests/Controllers/PlaylistsControllerTests.cs
+++ b/MediaPi.Core.Tests/Controllers/PlaylistsControllerTests.cs
@@ -18,6 +18,7 @@ using MediaPi.Core.Models;
 using MediaPi.Core.RestModels;
 using MediaPi.Core.Services;
 using MediaPi.Core.Extensions;
+using MediaPi.Core.Tests.TestHelpers;
 
 namespace MediaPi.Core.Tests.Controllers;
 
@@ -139,6 +140,7 @@ public class PlaylistsControllerTests
         _controller = new PlaylistsController(
             _mockHttpContextAccessor.Object,
             _userInformationService,
+            SubscriptionTestServices.PlaylistAccessService(_dbContext),
             _dbContext,
             _mockLogger.Object)
         {
@@ -238,6 +240,82 @@ public class PlaylistsControllerTests
         Assert.That(result.Result, Is.TypeOf<ObjectResult>());
         var obj = (ObjectResult)result.Result!;
         Assert.That(obj.StatusCode, Is.EqualTo(StatusCodes.Status400BadRequest));
+    }
+
+    [Test]
+    public async Task CreatePlaylist_CommonPaidCategoryWithoutSubscription_Returns400()
+    {
+        SetCurrentUser(_admin.Id);
+        var category = new Category { Id = 10, Title = "Premium", Free = false };
+        var video = new Video
+        {
+            Id = 10,
+            Title = "Common premium",
+            Filename = "premium.mp4",
+            OriginalFilename = "premium.mp4",
+            FileSizeBytes = 100,
+            AccountId = null,
+            CategoryId = category.Id,
+            Category = category
+        };
+        _dbContext.Categories.Add(category);
+        _dbContext.Videos.Add(video);
+        await _dbContext.SaveChangesAsync();
+
+        var item = new PlaylistCreateItem
+        {
+            Title = "New",
+            Filename = "premium.json",
+            AccountId = _account1.Id,
+            Items = [new PlaylistItemDto { VideoId = video.Id, Position = 0 }]
+        };
+
+        var result = await _controller.CreatePlaylist(item);
+
+        Assert.That(result.Result, Is.TypeOf<ObjectResult>());
+        var obj = (ObjectResult)result.Result!;
+        Assert.That(obj.StatusCode, Is.EqualTo(StatusCodes.Status400BadRequest));
+        Assert.That(((ErrMessage)obj.Value!).Msg, Does.Contain("подписки"));
+    }
+
+    [Test]
+    public async Task CreatePlaylist_CommonPaidCategoryWithValidSubscription_Creates()
+    {
+        SetCurrentUser(_admin.Id);
+        var category = new Category { Id = 11, Title = "Premium valid", Free = false };
+        var video = new Video
+        {
+            Id = 11,
+            Title = "Common premium valid",
+            Filename = "premium-valid.mp4",
+            OriginalFilename = "premium-valid.mp4",
+            FileSizeBytes = 100,
+            AccountId = null,
+            CategoryId = category.Id,
+            Category = category
+        };
+        _dbContext.Categories.Add(category);
+        _dbContext.Videos.Add(video);
+        _dbContext.Subscriptions.Add(new Subscription
+        {
+            AccountId = _account1.Id,
+            CategoryId = category.Id,
+            StartTime = new DateTime(2026, 5, 1, 0, 0, 0, DateTimeKind.Utc),
+            EndTime = new DateTime(2026, 7, 1, 0, 0, 0, DateTimeKind.Utc)
+        });
+        await _dbContext.SaveChangesAsync();
+
+        var item = new PlaylistCreateItem
+        {
+            Title = "New",
+            Filename = "premium-valid.json",
+            AccountId = _account1.Id,
+            Items = [new PlaylistItemDto { VideoId = video.Id, Position = 0 }]
+        };
+
+        var result = await _controller.CreatePlaylist(item);
+
+        Assert.That(result.Result, Is.TypeOf<CreatedAtActionResult>());
     }
 
     [Test]

--- a/MediaPi.Core.Tests/Controllers/VideosControllerTests.cs
+++ b/MediaPi.Core.Tests/Controllers/VideosControllerTests.cs
@@ -15,6 +15,7 @@ using MediaPi.Core.Models;
 using MediaPi.Core.RestModels;
 using MediaPi.Core.Services;
 using MediaPi.Core.Services.Interfaces;
+using MediaPi.Core.Tests.TestHelpers;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
@@ -136,6 +137,7 @@ public class VideosControllerTests
             _mockHttpContextAccessor.Object,
             _userInformationService,
             _mockVideoStorageService.Object,
+            SubscriptionTestServices.PlaylistAccessService(_dbContext),
             _dbContext,
             _mockLogger.Object)
         {
@@ -1168,6 +1170,180 @@ public class VideosControllerTests
         
         // Verify delete was NOT called since there was no conflict
         _mockVideoStorageService.Verify(s => s.DeleteVideoAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    // ──────────────────────────────────────────────────────
+    // GetVideosByAccount – availableForAccountId filter
+    // ──────────────────────────────────────────────────────
+
+    [Test]
+    public async Task GetVideosByAccount_AvailableForAccountId_FiltersInaccessibleVideos()
+    {
+        // Common paid video in paid category (account1 has NO active subscription → inaccessible)
+        var paidCategory = new Category { Id = 10, Title = "Paid", Free = false };
+        _dbContext.Categories.Add(paidCategory);
+        var paidVideo = new Video
+        {
+            Id = 100,
+            Title = "PaidVideo",
+            Filename = "0001/paid.mp4",
+            OriginalFilename = "paid.mp4",
+            FileSizeBytes = 100,
+            AccountId = null,
+            CategoryId = paidCategory.Id
+        };
+        _dbContext.Videos.Add(paidVideo);
+        await _dbContext.SaveChangesAsync();
+
+        SetCurrentUser(_admin.Id);
+        var result = await _controller.GetVideosByAccount(0, availableForAccountId: _account1.Id);
+
+        Assert.That(result.Value, Is.Not.Null);
+        // The paid video should be filtered out (no subscription)
+        var ids = result.Value!.Select(v => v.Id).ToList();
+        Assert.That(ids, Does.Not.Contain(paidVideo.Id));
+        // The original common free-category video (_videoCommon) should remain (uncategorized → free)
+        Assert.That(ids, Does.Contain(_videoCommon.Id));
+    }
+
+    [Test]
+    public async Task GetVideosByAccount_AvailableForAccountId_AccountNotFound_Returns404()
+    {
+        SetCurrentUser(_admin.Id);
+        var result = await _controller.GetVideosByAccount(0, availableForAccountId: 9999);
+        Assert.That(result.Result, Is.TypeOf<ObjectResult>());
+        Assert.That(((ObjectResult)result.Result!).StatusCode, Is.EqualTo(StatusCodes.Status404NotFound));
+    }
+
+    [Test]
+    public async Task GetVideosByAccount_AvailableForAccountId_ManagerOtherAccount_Returns403()
+    {
+        SetCurrentUser(_managerAccount1.Id); // manager for account1 only
+        var result = await _controller.GetVideosByAccount(0, availableForAccountId: _account2.Id);
+        Assert.That(result.Result, Is.TypeOf<ObjectResult>());
+        Assert.That(((ObjectResult)result.Result!).StatusCode, Is.EqualTo(StatusCodes.Status403Forbidden));
+    }
+
+    // ──────────────────────────────────────────────────────
+    // UpdateVideo – category change with playlist impact
+    // ──────────────────────────────────────────────────────
+
+    [Test]
+    public async Task UpdateVideo_CategoryChangeCausesImpact_Returns409()
+    {
+        // Setup: common video in free category, in playlist of account1 (account1 has no subscription for paid category)
+        var paidCat = new Category { Id = 20, Title = "Paid20", Free = false };
+        _dbContext.Categories.Add(paidCat);
+        _videoCommon.CategoryId = _categoryNews.Id;
+        _videoCommon.Category = _categoryNews;
+        _dbContext.VideoPlaylists.Add(new VideoPlaylist
+        {
+            Id = 200,
+            VideoId = _videoCommon.Id,
+            Video = _videoCommon,
+            PlaylistId = _playlistAccount1.Id,
+            Playlist = _playlistAccount1,
+            Position = 10
+        });
+        await _dbContext.SaveChangesAsync();
+
+        SetCurrentUser(_admin.Id);
+        // Move video from free category to paid category → account1 has no subscription → impact
+        var result = await _controller.UpdateVideo(_videoCommon.Id, new VideoUpdateItem { CategoryId = paidCat.Id });
+
+        Assert.That(result, Is.TypeOf<ObjectResult>());
+        Assert.That(((ObjectResult)result).StatusCode, Is.EqualTo(StatusCodes.Status409Conflict));
+    }
+
+    [Test]
+    public async Task UpdateVideo_CategoryChangeWithForceCleanup_RemovesPlaylistItems()
+    {
+        var paidCat = new Category { Id = 21, Title = "Paid21", Free = false };
+        _dbContext.Categories.Add(paidCat);
+        _videoCommon.CategoryId = _categoryNews.Id;
+        _videoCommon.Category = _categoryNews;
+        _dbContext.VideoPlaylists.Add(new VideoPlaylist
+        {
+            Id = 210,
+            VideoId = _videoCommon.Id,
+            Video = _videoCommon,
+            PlaylistId = _playlistAccount1.Id,
+            Playlist = _playlistAccount1,
+            Position = 10
+        });
+        await _dbContext.SaveChangesAsync();
+
+        SetCurrentUser(_admin.Id);
+        var result = await _controller.UpdateVideo(_videoCommon.Id, new VideoUpdateItem
+        {
+            CategoryId = paidCat.Id,
+            ForcePlaylistCleanup = true
+        });
+
+        Assert.That(result, Is.TypeOf<NoContentResult>());
+        Assert.That(_dbContext.VideoPlaylists.Any(vp => vp.Id == 210), Is.False);
+        Assert.That((await _dbContext.Videos.FindAsync(_videoCommon.Id))!.CategoryId, Is.EqualTo(paidCat.Id));
+    }
+
+    // ──────────────────────────────────────────────────────
+    // UpdateVideoCategories – playlist impact
+    // ──────────────────────────────────────────────────────
+
+    [Test]
+    public async Task UpdateVideoCategories_WithImpactNoForce_Returns409()
+    {
+        var paidCat = new Category { Id = 30, Title = "Paid30", Free = false };
+        _dbContext.Categories.Add(paidCat);
+        _videoCommon.CategoryId = _categoryNews.Id;
+        _videoCommon.Category = _categoryNews;
+        _dbContext.VideoPlaylists.Add(new VideoPlaylist
+        {
+            Id = 300,
+            VideoId = _videoCommon.Id,
+            Video = _videoCommon,
+            PlaylistId = _playlistAccount1.Id,
+            Playlist = _playlistAccount1,
+            Position = 10
+        });
+        await _dbContext.SaveChangesAsync();
+
+        SetCurrentUser(_admin.Id);
+        var result = await _controller.UpdateVideoCategories(
+            new VideoBatchCategoryUpdateItem { Ids = [_videoCommon.Id], CategoryId = paidCat.Id });
+
+        Assert.That(result.Result, Is.TypeOf<ObjectResult>());
+        Assert.That(((ObjectResult)result.Result!).StatusCode, Is.EqualTo(StatusCodes.Status409Conflict));
+    }
+
+    [Test]
+    public async Task UpdateVideoCategories_WithImpactForceCleanup_RemovesItems()
+    {
+        var paidCat = new Category { Id = 31, Title = "Paid31", Free = false };
+        _dbContext.Categories.Add(paidCat);
+        _videoCommon.CategoryId = _categoryNews.Id;
+        _videoCommon.Category = _categoryNews;
+        _dbContext.VideoPlaylists.Add(new VideoPlaylist
+        {
+            Id = 310,
+            VideoId = _videoCommon.Id,
+            Video = _videoCommon,
+            PlaylistId = _playlistAccount1.Id,
+            Playlist = _playlistAccount1,
+            Position = 10
+        });
+        await _dbContext.SaveChangesAsync();
+
+        SetCurrentUser(_admin.Id);
+        var result = await _controller.UpdateVideoCategories(
+            new VideoBatchCategoryUpdateItem
+            {
+                Ids = [_videoCommon.Id],
+                CategoryId = paidCat.Id,
+                ForcePlaylistCleanup = true
+            });
+
+        Assert.That(result.Result, Is.TypeOf<OkObjectResult>());
+        Assert.That(_dbContext.VideoPlaylists.Any(vp => vp.Id == 310), Is.False);
     }
 
 }

--- a/MediaPi.Core.Tests/RestModels/SubscriptionModelsTests.cs
+++ b/MediaPi.Core.Tests/RestModels/SubscriptionModelsTests.cs
@@ -1,0 +1,176 @@
+// Copyright (C) 2025-2026 sw.consulting
+// This file is a part of Media Pi backend
+
+using MediaPi.Core.Models;
+using MediaPi.Core.RestModels;
+using MediaPi.Core.Tests.TestHelpers;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+
+namespace MediaPi.Core.Tests.RestModels;
+
+[TestFixture]
+public class SubscriptionModelsTests
+{
+    private static readonly DateTime UtcReference = new(2026, 6, 1, 9, 0, 0, DateTimeKind.Utc);
+
+    // ──────────────────────────────────────────────────────
+    // SubscriptionViewItem – default constructor
+    // ──────────────────────────────────────────────────────
+
+    [Test]
+    public void SubscriptionViewItem_DefaultConstructor_HasSensibleDefaults()
+    {
+        var item = new SubscriptionViewItem();
+        Assert.That(item.Id, Is.EqualTo(0));
+        Assert.That(item.CategoryTitle, Is.EqualTo(string.Empty));
+        Assert.That(item.IsActive, Is.False);
+    }
+
+    // ──────────────────────────────────────────────────────
+    // SubscriptionViewItem – subscription constructor
+    // ──────────────────────────────────────────────────────
+
+    [Test]
+    public void SubscriptionViewItem_FromSubscription_ActiveWithinRange()
+    {
+        var category = new Category { Id = 3, Title = "Paid", Free = false };
+        var subscription = new Subscription
+        {
+            Id = 7,
+            AccountId = 2,
+            CategoryId = category.Id,
+            Category = category,
+            StartTime = new DateTime(2026, 6, 1, 0, 0, 0, DateTimeKind.Utc),
+            EndTime = new DateTime(2026, 6, 30, 23, 59, 59, DateTimeKind.Utc)
+        };
+        var timeService = SubscriptionTestServices.TimeService(UtcReference);
+
+        var item = new SubscriptionViewItem(subscription, timeService);
+
+        Assert.That(item.Id, Is.EqualTo(7));
+        Assert.That(item.AccountId, Is.EqualTo(2));
+        Assert.That(item.CategoryId, Is.EqualTo(3));
+        Assert.That(item.CategoryTitle, Is.EqualTo("Paid"));
+        Assert.That(item.IsActive, Is.True);
+        // StartDate should be June 1 in Moscow time (UTC+3): start of UTC June 1 → Moscow June 1
+        Assert.That(item.StartDate, Is.EqualTo(new DateOnly(2026, 6, 1)));
+        // End UTC 2026-06-30 23:59:59 → Moscow 2026-07-01 02:59:59 → date is July 1
+        Assert.That(item.EndDate, Is.EqualTo(new DateOnly(2026, 7, 1)));
+    }
+
+    [Test]
+    public void SubscriptionViewItem_FromSubscription_InactiveWhenExpired()
+    {
+        var category = new Category { Id = 3, Title = "Paid", Free = false };
+        var subscription = new Subscription
+        {
+            Id = 8,
+            AccountId = 2,
+            CategoryId = category.Id,
+            Category = category,
+            StartTime = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+            EndTime = new DateTime(2026, 5, 31, 23, 59, 59, DateTimeKind.Utc)
+        };
+        var timeService = SubscriptionTestServices.TimeService(UtcReference);
+
+        var item = new SubscriptionViewItem(subscription, timeService);
+
+        Assert.That(item.IsActive, Is.False);
+    }
+
+    [Test]
+    public void SubscriptionViewItem_FromSubscription_NullCategory_UsesEmptyTitle()
+    {
+        var subscription = new Subscription
+        {
+            Id = 9,
+            AccountId = 2,
+            CategoryId = 3,
+            Category = null!,
+            StartTime = new DateTime(2026, 6, 1, 0, 0, 0, DateTimeKind.Utc),
+            EndTime = new DateTime(2026, 6, 30, 23, 59, 59, DateTimeKind.Utc)
+        };
+        var timeService = SubscriptionTestServices.TimeService(UtcReference);
+
+        var item = new SubscriptionViewItem(subscription, timeService);
+
+        Assert.That(item.CategoryTitle, Is.EqualTo(string.Empty));
+    }
+
+    // ──────────────────────────────────────────────────────
+    // ToString – produces valid JSON
+    // ──────────────────────────────────────────────────────
+
+    [Test]
+    public void SubscriptionViewItem_ToString_ContainsId()
+    {
+        var item = new SubscriptionViewItem { Id = 42 };
+        Assert.That(item.ToString(), Does.Contain("42"));
+    }
+
+    [Test]
+    public void AccountSubscriptionsViewItem_ToString_ContainsSubscriptions()
+    {
+        var viewItem = new AccountSubscriptionsViewItem
+        {
+            Subscriptions = [new SubscriptionViewItem { Id = 10 }],
+            AvailableCategories = []
+        };
+        Assert.That(viewItem.ToString(), Does.Contain("10"));
+    }
+
+    [Test]
+    public void SubscriptionUpsertItem_ToString_ContainsDates()
+    {
+        var item = new SubscriptionUpsertItem
+        {
+            StartDate = new DateOnly(2026, 6, 1),
+            EndDate = new DateOnly(2026, 6, 30)
+        };
+        Assert.That(item.ToString(), Does.Contain("2026"));
+    }
+
+    // ──────────────────────────────────────────────────────
+    // PlaylistAccessImpact
+    // ──────────────────────────────────────────────────────
+
+    [Test]
+    public void PlaylistAccessImpact_HasImpact_TrueWhenAffectedItemCountPositive()
+    {
+        var impact = new PlaylistAccessImpact { AffectedItemCount = 3 };
+        Assert.That(impact.HasImpact, Is.True);
+    }
+
+    [Test]
+    public void PlaylistAccessImpact_HasImpact_FalseWhenZero()
+    {
+        var impact = new PlaylistAccessImpact();
+        Assert.That(impact.HasImpact, Is.False);
+    }
+
+    [Test]
+    public void PlaylistAccessImpact_ToString_ContainsCounts()
+    {
+        var impact = new PlaylistAccessImpact
+        {
+            AffectedPlaylistCount = 2,
+            AffectedItemCount = 5,
+            AffectedVideoCount = 3,
+            AffectedPlaylists = []
+        };
+        var json = impact.ToString();
+        Assert.That(json, Does.Contain("2"));
+        Assert.That(json, Does.Contain("5"));
+    }
+
+    [Test]
+    public void PlaylistCleanupResult_DefaultsToZero()
+    {
+        var result = new PlaylistCleanupResult();
+        Assert.That(result.RemovedItemCount, Is.EqualTo(0));
+        Assert.That(result.AffectedPlaylistCount, Is.EqualTo(0));
+        Assert.That(result.AffectedVideoCount, Is.EqualTo(0));
+    }
+}

--- a/MediaPi.Core.Tests/Services/PlaylistAccessServiceTests.cs
+++ b/MediaPi.Core.Tests/Services/PlaylistAccessServiceTests.cs
@@ -1,0 +1,391 @@
+// Copyright (C) 2025-2026 sw.consulting
+// This file is a part of Media Pi backend
+
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using MediaPi.Core.Data;
+using MediaPi.Core.Models;
+using MediaPi.Core.Services.Interfaces;
+using MediaPi.Core.Tests.TestHelpers;
+using Microsoft.EntityFrameworkCore;
+using NUnit.Framework;
+
+namespace MediaPi.Core.Tests.Services;
+
+[TestFixture]
+public class PlaylistAccessServiceTests
+{
+#pragma warning disable CS8618
+    private AppDbContext _db;
+    private IPlaylistAccessService _service;
+    private Account _account;
+    private Category _freeCategory;
+    private Category _paidCategory;
+#pragma warning restore CS8618
+
+    [SetUp]
+    public void Setup()
+    {
+        var options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase($"playlist_access_service_{Guid.NewGuid()}")
+            .Options;
+        _db = new AppDbContext(options);
+        _service = SubscriptionTestServices.PlaylistAccessService(_db);
+
+        _account = new Account { Id = 1, Name = "Account" };
+        _freeCategory = new Category { Id = 1, Title = "Free", Free = true };
+        _paidCategory = new Category { Id = 2, Title = "Paid", Free = false };
+        _db.Accounts.Add(_account);
+        _db.Categories.AddRange(_freeCategory, _paidCategory);
+        _db.SaveChanges();
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        _db.Database.EnsureDeleted();
+        _db.Dispose();
+    }
+
+    [Test]
+    public async Task GetAccessibleVideoIdsForAccount_AppliesCommonCategoryAndSubscriptionRules()
+    {
+        var uncategorized = AddVideo(1, null, null);
+        var free = AddVideo(2, null, _freeCategory.Id);
+        var paid = AddVideo(3, null, _paidCategory.Id);
+        var accountOwned = AddVideo(4, _account.Id, null);
+        var otherOwned = AddVideo(5, 99, null);
+        _db.Subscriptions.Add(new Subscription
+        {
+            AccountId = _account.Id,
+            CategoryId = _paidCategory.Id,
+            StartTime = new DateTime(2026, 5, 1, 0, 0, 0, DateTimeKind.Utc),
+            EndTime = new DateTime(2026, 7, 1, 0, 0, 0, DateTimeKind.Utc)
+        });
+        await _db.SaveChangesAsync();
+
+        var accessible = await _service.GetAccessibleVideoIdsForAccountAsync(
+            _account.Id,
+            new[] { uncategorized.Id, free.Id, paid.Id, accountOwned.Id, otherOwned.Id });
+
+        Assert.That(accessible, Is.EquivalentTo(new[] { uncategorized.Id, free.Id, paid.Id, accountOwned.Id }));
+    }
+
+    [Test]
+    public async Task BuildCategoryFreeChangeImpact_ReturnsAffectedPlaylistList()
+    {
+        var video = AddVideo(10, null, _freeCategory.Id);
+        var playlist = new Playlist { Id = 10, Title = "Main", Filename = "main.m3u", AccountId = _account.Id, Account = _account };
+        _db.Playlists.Add(playlist);
+        _db.VideoPlaylists.AddRange(
+            new VideoPlaylist { Id = 100, PlaylistId = playlist.Id, Playlist = playlist, VideoId = video.Id, Video = video, Position = 0 },
+            new VideoPlaylist { Id = 101, PlaylistId = playlist.Id, Playlist = playlist, VideoId = video.Id, Video = video, Position = 1 });
+        await _db.SaveChangesAsync();
+
+        var impact = await _service.BuildCategoryFreeChangeImpactAsync(_freeCategory.Id, false);
+
+        Assert.That(impact.AffectedPlaylistCount, Is.EqualTo(1));
+        Assert.That(impact.AffectedItemCount, Is.EqualTo(2));
+        Assert.That(impact.AffectedVideoCount, Is.EqualTo(1));
+        Assert.That(impact.AffectedPlaylists.Single().Title, Is.EqualTo("Main"));
+        Assert.That(impact.AffectedPlaylists.Single().RemovedItemCount, Is.EqualTo(2));
+        Assert.That(impact.VideoPlaylistIds, Is.EquivalentTo(new[] { 100, 101 }));
+    }
+
+    [Test]
+    public async Task RemoveCurrentInvalidPlaylistItems_RemovesExpiredSubscriptionRows()
+    {
+        var video = AddVideo(20, null, _paidCategory.Id);
+        var playlist = new Playlist { Id = 20, Title = "Expired", Filename = "expired.m3u", AccountId = _account.Id, Account = _account };
+        _db.Playlists.Add(playlist);
+        _db.VideoPlaylists.Add(new VideoPlaylist { Id = 200, PlaylistId = playlist.Id, Playlist = playlist, VideoId = video.Id, Video = video, Position = 0 });
+        _db.Subscriptions.Add(new Subscription
+        {
+            AccountId = _account.Id,
+            CategoryId = _paidCategory.Id,
+            StartTime = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+            EndTime = new DateTime(2026, 2, 1, 0, 0, 0, DateTimeKind.Utc)
+        });
+        await _db.SaveChangesAsync();
+
+        var result = await _service.RemoveCurrentInvalidPlaylistItemsAsync();
+
+        Assert.That(result.RemovedItemCount, Is.EqualTo(1));
+        Assert.That(await _db.VideoPlaylists.AnyAsync(vp => vp.Id == 200), Is.False);
+    }
+
+    // ──────────────────────────────────────────────────────
+    // GetInaccessibleVideoIds
+    // ──────────────────────────────────────────────────────
+
+    [Test]
+    public async Task GetInaccessibleVideoIds_EmptyList_ReturnsEmpty()
+    {
+        var result = await _service.GetInaccessibleVideoIdsForAccountAsync(_account.Id, []);
+        Assert.That(result, Is.Empty);
+    }
+
+    [Test]
+    public async Task GetInaccessibleVideoIds_PaidVideoWithoutSubscription_IsInaccessible()
+    {
+        var paid = AddVideo(30, null, _paidCategory.Id);
+        await _db.SaveChangesAsync();
+
+        var result = await _service.GetInaccessibleVideoIdsForAccountAsync(_account.Id, [paid.Id]);
+
+        Assert.That(result, Is.EquivalentTo(new[] { paid.Id }));
+    }
+
+    [Test]
+    public async Task GetInaccessibleVideoIds_FreeVideo_IsAccessible()
+    {
+        var free = AddVideo(31, null, _freeCategory.Id);
+        await _db.SaveChangesAsync();
+
+        var result = await _service.GetInaccessibleVideoIdsForAccountAsync(_account.Id, [free.Id]);
+
+        Assert.That(result, Is.Empty);
+    }
+
+    // ──────────────────────────────────────────────────────
+    // AccountCanAccessVideo
+    // ──────────────────────────────────────────────────────
+
+    [Test]
+    public async Task AccountCanAccessVideo_OwnVideo_ReturnsTrue()
+    {
+        var own = AddVideo(40, _account.Id, null);
+        await _db.SaveChangesAsync();
+
+        var result = await _service.AccountCanAccessVideoAsync(_account.Id, own.Id);
+
+        Assert.That(result, Is.True);
+    }
+
+    [Test]
+    public async Task AccountCanAccessVideo_OtherAccountVideo_ReturnsFalse()
+    {
+        var other = AddVideo(41, 99, null);
+        await _db.SaveChangesAsync();
+
+        var result = await _service.AccountCanAccessVideoAsync(_account.Id, other.Id);
+
+        Assert.That(result, Is.False);
+    }
+
+    [Test]
+    public async Task AccountCanAccessVideo_PaidWithActiveSubscription_ReturnsTrue()
+    {
+        var paid = AddVideo(42, null, _paidCategory.Id);
+        _db.Subscriptions.Add(new Subscription
+        {
+            AccountId = _account.Id,
+            CategoryId = _paidCategory.Id,
+            StartTime = new DateTime(2026, 5, 1, 0, 0, 0, DateTimeKind.Utc),
+            EndTime = new DateTime(2026, 7, 1, 0, 0, 0, DateTimeKind.Utc)
+        });
+        await _db.SaveChangesAsync();
+
+        var result = await _service.AccountCanAccessVideoAsync(_account.Id, paid.Id);
+
+        Assert.That(result, Is.True);
+    }
+
+    // ──────────────────────────────────────────────────────
+    // GetAccessibleVideoIds – empty input
+    // ──────────────────────────────────────────────────────
+
+    [Test]
+    public async Task GetAccessibleVideoIds_EmptyList_ReturnsEmpty()
+    {
+        var result = await _service.GetAccessibleVideoIdsForAccountAsync(_account.Id, []);
+        Assert.That(result, Is.Empty);
+    }
+
+    [Test]
+    public async Task GetAccessibleVideoIds_UncategorizedCommonVideo_IsAccessible()
+    {
+        var uncategorized = AddVideo(50, null, null);
+        await _db.SaveChangesAsync();
+
+        var result = await _service.GetAccessibleVideoIdsForAccountAsync(_account.Id, [uncategorized.Id]);
+
+        Assert.That(result, Does.Contain(uncategorized.Id));
+    }
+
+    // ──────────────────────────────────────────────────────
+    // BuildCurrentInvalidPlaylistImpactAsync
+    // ──────────────────────────────────────────────────────
+
+    [Test]
+    public async Task BuildCurrentInvalidPlaylistImpact_NoPlaylists_ReturnsEmptyImpact()
+    {
+        var impact = await _service.BuildCurrentInvalidPlaylistImpactAsync();
+        Assert.That(impact.HasImpact, Is.False);
+    }
+
+    // ──────────────────────────────────────────────────────
+    // BuildSubscriptionChangeImpactAsync
+    // ──────────────────────────────────────────────────────
+
+    [Test]
+    public async Task BuildSubscriptionChangeImpact_SubscriptionBecomesActive_NoImpact()
+    {
+        // Video in paid category, playlist belongs to account
+        var video = AddVideo(60, null, _paidCategory.Id);
+        var playlist = new Playlist { Id = 60, Title = "P60", Filename = "p60.m3u", AccountId = _account.Id, Account = _account };
+        _db.Playlists.Add(playlist);
+        _db.VideoPlaylists.Add(new VideoPlaylist { Id = 600, PlaylistId = playlist.Id, Playlist = playlist, VideoId = video.Id, Video = video, Position = 0 });
+        await _db.SaveChangesAsync();
+
+        // Propose a start/end that covers "now" (UtcNow = 2026-06-01 09:00)
+        var start = new DateTime(2026, 6, 1, 0, 0, 0, DateTimeKind.Utc);
+        var end = new DateTime(2026, 6, 30, 23, 59, 59, DateTimeKind.Utc);
+        var impact = await _service.BuildSubscriptionChangeImpactAsync(_account.Id, _paidCategory.Id, start, end);
+
+        // Active subscription → video accessible → no impact
+        Assert.That(impact.HasImpact, Is.False);
+    }
+
+    [Test]
+    public async Task BuildSubscriptionChangeImpact_SubscriptionBecomesInactive_ReturnsImpact()
+    {
+        // Video in paid category, playlist belongs to account
+        var video = AddVideo(61, null, _paidCategory.Id);
+        var playlist = new Playlist { Id = 61, Title = "P61", Filename = "p61.m3u", AccountId = _account.Id, Account = _account };
+        _db.Playlists.Add(playlist);
+        _db.VideoPlaylists.Add(new VideoPlaylist { Id = 610, PlaylistId = playlist.Id, Playlist = playlist, VideoId = video.Id, Video = video, Position = 0 });
+        await _db.SaveChangesAsync();
+
+        // Propose a start/end that is in the future (UtcNow = 2026-06-01 09:00)
+        var start = new DateTime(2026, 7, 1, 0, 0, 0, DateTimeKind.Utc);
+        var end = new DateTime(2026, 7, 31, 23, 59, 59, DateTimeKind.Utc);
+        var impact = await _service.BuildSubscriptionChangeImpactAsync(_account.Id, _paidCategory.Id, start, end);
+
+        // Inactive subscription → video not accessible → has impact
+        Assert.That(impact.HasImpact, Is.True);
+        Assert.That(impact.VideoPlaylistIds, Does.Contain(610));
+    }
+
+    // ──────────────────────────────────────────────────────
+    // BuildVideoCategoryChangeImpactAsync
+    // ──────────────────────────────────────────────────────
+
+    [Test]
+    public async Task BuildVideoCategoryChangeImpact_EmptyVideoIds_ReturnsNoImpact()
+    {
+        var impact = await _service.BuildVideoCategoryChangeImpactAsync([], null);
+        Assert.That(impact.HasImpact, Is.False);
+    }
+
+    [Test]
+    public async Task BuildVideoCategoryChangeImpact_MovingToPaidCategory_ReturnsImpact()
+    {
+        // Free video in a playlist; propose to move it to paid category (no active subscription)
+        var video = AddVideo(70, null, _freeCategory.Id);
+        var playlist = new Playlist { Id = 70, Title = "P70", Filename = "p70.m3u", AccountId = _account.Id, Account = _account };
+        _db.Playlists.Add(playlist);
+        _db.VideoPlaylists.Add(new VideoPlaylist { Id = 700, PlaylistId = playlist.Id, Playlist = playlist, VideoId = video.Id, Video = video, Position = 0 });
+        await _db.SaveChangesAsync();
+
+        var impact = await _service.BuildVideoCategoryChangeImpactAsync([video.Id], _paidCategory.Id);
+
+        Assert.That(impact.HasImpact, Is.True);
+        Assert.That(impact.VideoPlaylistIds, Does.Contain(700));
+    }
+
+    // ──────────────────────────────────────────────────────
+    // RemovePlaylistItemsAsync – edge cases
+    // ──────────────────────────────────────────────────────
+
+    [Test]
+    public async Task RemovePlaylistItems_EmptyList_ReturnsZeroCounts()
+    {
+        var result = await _service.RemovePlaylistItemsAsync([]);
+        Assert.That(result.RemovedItemCount, Is.EqualTo(0));
+    }
+
+    [Test]
+    public async Task RemovePlaylistItems_NonExistentIds_ReturnsZeroCounts()
+    {
+        var result = await _service.RemovePlaylistItemsAsync([99999, 88888]);
+        Assert.That(result.RemovedItemCount, Is.EqualTo(0));
+    }
+
+    [Test]
+    public async Task RemovePlaylistItems_ValidIds_RemovesAndReturnsCorrectCounts()
+    {
+        var video = AddVideo(80, null, _freeCategory.Id);
+        var playlist = new Playlist { Id = 80, Title = "P80", Filename = "p80.m3u", AccountId = _account.Id, Account = _account };
+        _db.Playlists.Add(playlist);
+        _db.VideoPlaylists.AddRange(
+            new VideoPlaylist { Id = 800, PlaylistId = playlist.Id, Playlist = playlist, VideoId = video.Id, Video = video, Position = 0 },
+            new VideoPlaylist { Id = 801, PlaylistId = playlist.Id, Playlist = playlist, VideoId = video.Id, Video = video, Position = 1 });
+        await _db.SaveChangesAsync();
+
+        var result = await _service.RemovePlaylistItemsAsync([800, 801]);
+
+        Assert.That(result.RemovedItemCount, Is.EqualTo(2));
+        Assert.That(result.AffectedPlaylistCount, Is.EqualTo(1));
+        Assert.That(result.AffectedVideoCount, Is.EqualTo(1));
+        Assert.That(await _db.VideoPlaylists.AnyAsync(vp => vp.Id == 800 || vp.Id == 801), Is.False);
+    }
+
+    // ──────────────────────────────────────────────────────
+    // BuildCategoryFreeChangeImpact – becomes free (no impact)
+    // ──────────────────────────────────────────────────────
+
+    [Test]
+    public async Task BuildCategoryFreeChangeImpact_BecomingFree_NoImpact()
+    {
+        // Paid video in playlist; propose to make category free
+        var video = AddVideo(90, null, _paidCategory.Id);
+        var playlist = new Playlist { Id = 90, Title = "P90", Filename = "p90.m3u", AccountId = _account.Id, Account = _account };
+        _db.Playlists.Add(playlist);
+        _db.VideoPlaylists.Add(new VideoPlaylist { Id = 900, PlaylistId = playlist.Id, Playlist = playlist, VideoId = video.Id, Video = video, Position = 0 });
+        await _db.SaveChangesAsync();
+
+        var impact = await _service.BuildCategoryFreeChangeImpactAsync(_paidCategory.Id, proposedFree: true);
+
+        // Making category free means all users can access → no removal needed
+        Assert.That(impact.HasImpact, Is.False);
+    }
+
+    // ──────────────────────────────────────────────────────
+    // RemoveCurrentInvalidPlaylistItemsAsync
+    // ──────────────────────────────────────────────────────
+
+    [Test]
+    public async Task RemoveCurrentInvalidPlaylistItems_AllAccessible_ReturnsZero()
+    {
+        // All videos are owned by the same account as the playlists → always accessible
+        var video = AddVideo(95, _account.Id, null);
+        var playlist = new Playlist { Id = 95, Title = "P95", Filename = "p95.m3u", AccountId = _account.Id, Account = _account };
+        _db.Playlists.Add(playlist);
+        _db.VideoPlaylists.Add(new VideoPlaylist { Id = 950, PlaylistId = playlist.Id, Playlist = playlist, VideoId = video.Id, Video = video, Position = 0 });
+        await _db.SaveChangesAsync();
+
+        var result = await _service.RemoveCurrentInvalidPlaylistItemsAsync();
+
+        Assert.That(result.RemovedItemCount, Is.EqualTo(0));
+        Assert.That(await _db.VideoPlaylists.AnyAsync(vp => vp.Id == 950), Is.True);
+    }
+
+    private Video AddVideo(int id, int? accountId, int? categoryId)
+    {
+        var video = new Video
+        {
+            Id = id,
+            Title = $"Video {id}",
+            Filename = $"video-{id}.mp4",
+            OriginalFilename = $"video-{id}.mp4",
+            FileSizeBytes = 100,
+            AccountId = accountId,
+            CategoryId = categoryId,
+            Sha256 = new string('a', 64)
+        };
+        _db.Videos.Add(video);
+        return video;
+    }
+}

--- a/MediaPi.Core.Tests/Services/SubscriptionMaintenanceServiceTests.cs
+++ b/MediaPi.Core.Tests/Services/SubscriptionMaintenanceServiceTests.cs
@@ -1,0 +1,120 @@
+// Copyright (C) 2025-2026 sw.consulting
+// This file is a part of Media Pi backend
+
+using MediaPi.Core.Data;
+using MediaPi.Core.Services;
+using MediaPi.Core.Services.Interfaces;
+using MediaPi.Core.Tests.TestHelpers;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Moq;
+using NUnit.Framework;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace MediaPi.Core.Tests.Services;
+
+[TestFixture]
+public class SubscriptionMaintenanceServiceTests
+{
+    private static (SubscriptionMaintenanceService service, AppDbContext db) BuildService(DateTime? utcNow = null)
+    {
+        var options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase($"sms_test_{Guid.NewGuid()}")
+            .Options;
+        var db = new AppDbContext(options);
+
+        var services = new ServiceCollection();
+        services.AddSingleton(db);
+        services.AddSingleton<IPlaylistAccessService>(_ =>
+            SubscriptionTestServices.PlaylistAccessService(db, utcNow));
+        var provider = services.BuildServiceProvider();
+
+        var timeService = SubscriptionTestServices.TimeService(utcNow);
+        var logger = new Mock<ILogger<SubscriptionMaintenanceService>>().Object;
+        var scopeFactory = provider.GetRequiredService<IServiceScopeFactory>();
+
+        return (new SubscriptionMaintenanceService(scopeFactory, timeService, logger), db);
+    }
+
+    [TearDown]
+    public void TearDown() { }
+
+    [Test]
+    public async Task RunCleanupOnceAsync_NoInvalidItems_ReturnsZeroCounts()
+    {
+        var (svc, db) = BuildService();
+        try
+        {
+            var result = await svc.RunCleanupOnceAsync();
+            Assert.That(result.RemovedItemCount, Is.EqualTo(0));
+            Assert.That(result.AffectedPlaylistCount, Is.EqualTo(0));
+            Assert.That(result.AffectedVideoCount, Is.EqualTo(0));
+        }
+        finally
+        {
+            db.Dispose();
+        }
+    }
+
+    [Test]
+    public void GetDelayUntilNextLocalMidnight_ReturnsPositiveDelay()
+    {
+        var (svc, db) = BuildService(new DateTime(2026, 6, 1, 9, 0, 0, DateTimeKind.Utc));
+        try
+        {
+            var delay = svc.GetDelayUntilNextLocalMidnight();
+            Assert.That(delay, Is.GreaterThan(TimeSpan.Zero));
+        }
+        finally
+        {
+            db.Dispose();
+        }
+    }
+
+    [Test]
+    public void GetDelayUntilNextLocalMidnight_WhenLocalTimeIsExactlyMidnight_ReturnsOneSecond()
+    {
+        // 2026-06-01 21:00:00 UTC = 2026-06-02 00:00:00 Moscow (exact midnight)
+        var utcMidnight = new DateTime(2026, 6, 1, 21, 0, 0, DateTimeKind.Utc);
+        var (svc, db) = BuildService(utcMidnight);
+        try
+        {
+            // local midnight => delay would be 24h, but we subtract local now from next midnight
+            // Actual local time is exactly midnight → next midnight is +24h → delay = 24h
+            // Actually: nextLocalMidnight = 2026-06-02 00:00 + 1 day = 2026-06-03 00:00
+            // Wait, let's think again:
+            // localNow = 2026-06-02 00:00:00
+            // localNow.Date = 2026-06-02 00:00:00
+            // nextLocalMidnight = 2026-06-03 00:00:00
+            // delay = 24h > 0 → returns 24h
+            var delay = svc.GetDelayUntilNextLocalMidnight();
+            Assert.That(delay, Is.EqualTo(TimeSpan.FromDays(1)).Within(TimeSpan.FromSeconds(1)));
+        }
+        finally
+        {
+            db.Dispose();
+        }
+    }
+
+    [Test]
+    public async Task ExecuteAsync_CancelsCleanly()
+    {
+        var (svc, db) = BuildService();
+        try
+        {
+            using var cts = new CancellationTokenSource();
+            // Cancel immediately after starting
+            cts.Cancel();
+            // Should complete without throwing (OperationCanceledException is swallowed)
+            await svc.StartAsync(cts.Token);
+            await svc.StopAsync(CancellationToken.None);
+        }
+        finally
+        {
+            db.Dispose();
+        }
+    }
+}

--- a/MediaPi.Core.Tests/Services/SubscriptionTimeServiceTests.cs
+++ b/MediaPi.Core.Tests/Services/SubscriptionTimeServiceTests.cs
@@ -1,0 +1,218 @@
+// Copyright (C) 2025-2026 sw.consulting
+// This file is a part of Media Pi backend
+
+using MediaPi.Core.Models;
+using MediaPi.Core.Services;
+using MediaPi.Core.Services.Interfaces;
+using MediaPi.Core.Settings;
+using MediaPi.Core.Tests.TestHelpers;
+using Microsoft.Extensions.Options;
+using NUnit.Framework;
+using System;
+
+namespace MediaPi.Core.Tests.Services;
+
+[TestFixture]
+public class SubscriptionTimeServiceTests
+{
+    // UTC 2026-06-01 09:00:00 => Moscow local 2026-06-01 12:00:00 (UTC+3)
+    private static readonly DateTime UtcReference = new(2026, 6, 1, 9, 0, 0, DateTimeKind.Utc);
+
+    private static SubscriptionTimeService Build(DateTime? utcNow = null) =>
+        (SubscriptionTimeService)SubscriptionTestServices.TimeService(utcNow ?? UtcReference);
+
+    // ──────────────────────────────────────────────────────
+    // UtcNow / LocalNow
+    // ──────────────────────────────────────────────────────
+
+    [Test]
+    public void UtcNow_ReturnsProvidedClockValue()
+    {
+        var svc = Build();
+        Assert.That(svc.UtcNow, Is.EqualTo(UtcReference));
+        Assert.That(svc.UtcNow.Kind, Is.EqualTo(DateTimeKind.Utc));
+    }
+
+    [Test]
+    public void LocalNow_ReturnsUtcPlusThreeHours()
+    {
+        var svc = Build();
+        // Moscow is UTC+3
+        var expected = UtcReference.AddHours(3);
+        Assert.That(svc.LocalNow, Is.EqualTo(expected).Within(TimeSpan.FromSeconds(1)));
+    }
+
+    // ──────────────────────────────────────────────────────
+    // ToUtcStart / ToUtcEnd
+    // ──────────────────────────────────────────────────────
+
+    [Test]
+    public void ToUtcStart_ConvertsMidnightLocalToUtc()
+    {
+        var svc = Build();
+        var local = new DateOnly(2026, 6, 1);
+        var result = svc.ToUtcStart(local);
+        // Midnight Moscow = UTC-3 = 2026-05-31 21:00:00 UTC
+        Assert.That(result, Is.EqualTo(new DateTime(2026, 5, 31, 21, 0, 0, DateTimeKind.Utc)));
+    }
+
+    [Test]
+    public void ToUtcEnd_ConvertsLastTickOfDayLocalToUtc()
+    {
+        var svc = Build();
+        var local = new DateOnly(2026, 6, 1);
+        var result = svc.ToUtcEnd(local);
+        // 23:59:59.9999999 Moscow = day+1 midnight - 1 tick - 3h UTC
+        var expected = new DateTime(2026, 6, 1, 20, 59, 59, 999, DateTimeKind.Utc)
+            .AddMicroseconds(999).AddTicks(9);
+        Assert.That(result.Date, Is.EqualTo(new DateTime(2026, 6, 1)));
+        // Should be close to end of June 1 converted from Moscow to UTC
+        Assert.That(result.TimeOfDay, Is.EqualTo(new TimeSpan(0, 20, 59, 59, 999).Add(TimeSpan.FromTicks(9999))));
+    }
+
+    // ──────────────────────────────────────────────────────
+    // ToLocalDate
+    // ──────────────────────────────────────────────────────
+
+    [Test]
+    public void ToLocalDate_ConvertsUtcToMoscowDate()
+    {
+        var svc = Build();
+        // 2026-06-01 22:00:00 UTC = 2026-06-02 01:00:00 Moscow → date is June 2
+        var utc = new DateTime(2026, 6, 1, 22, 0, 0, DateTimeKind.Utc);
+        Assert.That(svc.ToLocalDate(utc), Is.EqualTo(new DateOnly(2026, 6, 2)));
+    }
+
+    [Test]
+    public void ToLocalDate_UnspecifiedKind_TreatedAsUtc()
+    {
+        var svc = Build();
+        // Unspecified kind – EnsureUtc should treat it as Utc
+        var unspecified = DateTime.SpecifyKind(new DateTime(2026, 6, 1, 22, 0, 0), DateTimeKind.Unspecified);
+        Assert.That(svc.ToLocalDate(unspecified), Is.EqualTo(new DateOnly(2026, 6, 2)));
+    }
+
+    [Test]
+    public void ToLocalDate_LocalKind_ConvertsCorrectly()
+    {
+        var svc = Build();
+        var localTime = DateTime.SpecifyKind(new DateTime(2026, 6, 1, 12, 0, 0), DateTimeKind.Local);
+        // Result should be a valid DateOnly without throwing
+        var result = svc.ToLocalDate(localTime);
+        Assert.That(result.Year, Is.EqualTo(2026));
+    }
+
+    // ──────────────────────────────────────────────────────
+    // IsActive
+    // ──────────────────────────────────────────────────────
+
+    [Test]
+    public void IsActive_DateTime_ReturnsTrueWhenNowIsWithinRange()
+    {
+        var svc = Build(); // now = 2026-06-01 09:00 UTC
+        var start = new DateTime(2026, 6, 1, 0, 0, 0, DateTimeKind.Utc);
+        var end = new DateTime(2026, 6, 30, 23, 59, 59, DateTimeKind.Utc);
+        Assert.That(svc.IsActive(start, end), Is.True);
+    }
+
+    [Test]
+    public void IsActive_DateTime_ReturnsFalseWhenNowIsBeforeRange()
+    {
+        var svc = Build(); // now = 2026-06-01 09:00 UTC
+        var start = new DateTime(2026, 7, 1, 0, 0, 0, DateTimeKind.Utc);
+        var end = new DateTime(2026, 7, 31, 23, 59, 59, DateTimeKind.Utc);
+        Assert.That(svc.IsActive(start, end), Is.False);
+    }
+
+    [Test]
+    public void IsActive_DateTime_ReturnsFalseWhenNowIsAfterRange()
+    {
+        var svc = Build(); // now = 2026-06-01 09:00 UTC
+        var start = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        var end = new DateTime(2026, 5, 31, 23, 59, 59, DateTimeKind.Utc);
+        Assert.That(svc.IsActive(start, end), Is.False);
+    }
+
+    [Test]
+    public void IsActive_DateTime_ReturnsTrueOnStartBoundary()
+    {
+        var now = new DateTime(2026, 6, 1, 0, 0, 0, DateTimeKind.Utc);
+        var svc = Build(now);
+        Assert.That(svc.IsActive(now, now.AddDays(30)), Is.True);
+    }
+
+    [Test]
+    public void IsActive_DateTime_ReturnsTrueOnEndBoundary()
+    {
+        var end = new DateTime(2026, 6, 1, 0, 0, 0, DateTimeKind.Utc);
+        var svc = Build(end);
+        Assert.That(svc.IsActive(end.AddDays(-30), end), Is.True);
+    }
+
+    [Test]
+    public void IsActive_Subscription_DelegatesToDateTimeOverload()
+    {
+        var svc = Build(); // now = 2026-06-01 09:00 UTC
+        var subscription = new Subscription
+        {
+            Id = 1, AccountId = 1, CategoryId = 1,
+            StartTime = new DateTime(2026, 6, 1, 0, 0, 0, DateTimeKind.Utc),
+            EndTime = new DateTime(2026, 6, 30, 23, 59, 59, DateTimeKind.Utc)
+        };
+        Assert.That(svc.IsActive(subscription), Is.True);
+    }
+
+    [Test]
+    public void IsActive_Subscription_ReturnsFalseForExpiredSubscription()
+    {
+        var svc = Build(); // now = 2026-06-01 09:00 UTC
+        var subscription = new Subscription
+        {
+            Id = 1, AccountId = 1, CategoryId = 1,
+            StartTime = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+            EndTime = new DateTime(2026, 5, 31, 0, 0, 0, DateTimeKind.Utc)
+        };
+        Assert.That(svc.IsActive(subscription), Is.False);
+    }
+
+    // ──────────────────────────────────────────────────────
+    // ResolveTimeZone – fallback to custom when ID is invalid
+    // ──────────────────────────────────────────────────────
+
+    [Test]
+    public void ResolveTimeZone_InvalidId_FallsBackToMoscowOffset()
+    {
+        var svc = new SubscriptionTimeService(
+            Options.Create(new SubscriptionSettings { TimeZoneId = "Invalid/TimeZone/That/Does/Not/Exist" }),
+            new FixedClock(UtcReference));
+
+        // Should still be UTC+3 because the fallback custom zone has +3h offset
+        Assert.That(svc.TimeZone.BaseUtcOffset, Is.EqualTo(TimeSpan.FromHours(3)));
+    }
+
+    [Test]
+    public void ResolveTimeZone_NullId_FallsBackToMoscow()
+    {
+        var svc = new SubscriptionTimeService(
+            Options.Create(new SubscriptionSettings { TimeZoneId = null! }),
+            new FixedClock(UtcReference));
+
+        Assert.That(svc.TimeZone.BaseUtcOffset, Is.EqualTo(TimeSpan.FromHours(3)));
+    }
+
+    // ──────────────────────────────────────────────────────
+    // SubscriptionClock – ensures production clock is UTC
+    // ──────────────────────────────────────────────────────
+
+    [Test]
+    public void SubscriptionClock_UtcNow_IsUtcKind()
+    {
+        ISubscriptionClock clock = new SubscriptionClock();
+        Assert.That(clock.UtcNow.Kind, Is.EqualTo(DateTimeKind.Utc));
+    }
+
+    private sealed class FixedClock(DateTime utcNow) : ISubscriptionClock
+    {
+        public DateTime UtcNow { get; } = DateTime.SpecifyKind(utcNow, DateTimeKind.Utc);
+    }
+}

--- a/MediaPi.Core.Tests/TestHelpers/SubscriptionTestServices.cs
+++ b/MediaPi.Core.Tests/TestHelpers/SubscriptionTestServices.cs
@@ -1,0 +1,29 @@
+// Copyright (C) 2025-2026 sw.consulting
+// This file is a part of Media Pi backend
+
+using MediaPi.Core.Data;
+using MediaPi.Core.Services;
+using MediaPi.Core.Services.Interfaces;
+using MediaPi.Core.Settings;
+using Microsoft.Extensions.Options;
+using System;
+
+namespace MediaPi.Core.Tests.TestHelpers;
+
+internal static class SubscriptionTestServices
+{
+    public static ISubscriptionTimeService TimeService(DateTime? utcNow = null) =>
+        new SubscriptionTimeService(
+            Options.Create(new SubscriptionSettings { TimeZoneId = "Europe/Moscow" }),
+            new FixedSubscriptionClock(utcNow ?? new DateTime(2026, 6, 1, 9, 0, 0, DateTimeKind.Utc)));
+
+    public static IPlaylistAccessService PlaylistAccessService(AppDbContext db, DateTime? utcNow = null) =>
+        new PlaylistAccessService(db, TimeService(utcNow));
+
+    private sealed class FixedSubscriptionClock(DateTime utcNow) : ISubscriptionClock
+    {
+        public DateTime UtcNow { get; } = utcNow.Kind == DateTimeKind.Utc
+            ? utcNow
+            : DateTime.SpecifyKind(utcNow, DateTimeKind.Utc);
+    }
+}

--- a/MediaPi.Core/Controllers/AccountsController.cs
+++ b/MediaPi.Core/Controllers/AccountsController.cs
@@ -253,6 +253,53 @@ public class AccountsController(
         return NoContent();
     }
 
+    // DELETE: api/accounts/{id}/subscriptions/{categoryId}
+    [HttpDelete("{id}/subscriptions/{categoryId}")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden, Type = typeof(ErrMessage))]
+    [ProducesResponseType(StatusCodes.Status404NotFound, Type = typeof(ErrMessage))]
+    [ProducesResponseType(StatusCodes.Status409Conflict, Type = typeof(PlaylistAccessImpact))]
+    public async Task<IActionResult> DeleteSubscription(
+        int id,
+        int categoryId,
+        [FromBody] SubscriptionDeleteItem? item = null,
+        CancellationToken ct = default)
+    {
+        var user = await CurrentUser();
+        if (user == null || !user.IsAdministrator()) return _403();
+
+        var accountExists = await _db.Accounts.AsNoTracking().AnyAsync(a => a.Id == id, ct);
+        if (!accountExists) return _404Account(id);
+
+        var categoryExists = await _db.Categories.AsNoTracking().AnyAsync(c => c.Id == categoryId, ct);
+        if (!categoryExists) return _404Category(categoryId);
+
+        var subscription = await _db.Subscriptions
+            .FirstOrDefaultAsync(s => s.AccountId == id && s.CategoryId == categoryId, ct);
+        if (subscription == null) return NoContent();
+
+        var impact = await _playlistAccessService.BuildSubscriptionChangeImpactAsync(
+            id,
+            categoryId,
+            DateTime.UnixEpoch,
+            DateTime.UnixEpoch,
+            ct);
+        if (impact.HasImpact && item?.ForcePlaylistCleanup != true)
+        {
+            return StatusCode(StatusCodes.Status409Conflict, impact);
+        }
+
+        if (item?.ForcePlaylistCleanup == true && impact.HasImpact)
+        {
+            await _playlistAccessService.RemovePlaylistItemsAsync(impact.VideoPlaylistIds, ct);
+        }
+
+        _db.Subscriptions.Remove(subscription);
+        await _db.SaveChangesAsync(ct);
+
+        return NoContent();
+    }
+
     // POST: api/accounts
     [HttpPost]
     [ProducesResponseType(StatusCodes.Status201Created, Type = typeof(Reference))]

--- a/MediaPi.Core/Controllers/AccountsController.cs
+++ b/MediaPi.Core/Controllers/AccountsController.cs
@@ -20,10 +20,14 @@ namespace MediaPi.Core.Controllers;
 public class AccountsController(
     IHttpContextAccessor httpContextAccessor,
     IUserInformationService userInformationService,
+    IPlaylistAccessService playlistAccessService,
+    ISubscriptionTimeService subscriptionTimeService,
     AppDbContext db,
     ILogger<AccountsController> logger) : MediaPiControllerBase(httpContextAccessor, db, logger)
 {
     private readonly IUserInformationService _userInformationService = userInformationService;
+    private readonly IPlaylistAccessService _playlistAccessService = playlistAccessService;
+    private readonly ISubscriptionTimeService _subscriptionTimeService = subscriptionTimeService;
 
     // GET: api/accounts
     [HttpGet]
@@ -144,6 +148,109 @@ public class AccountsController(
 
         _logger.LogDebug("GetAccountsByManager returning {count} accounts", accounts.Count);
         return accounts;
+    }
+
+    // GET: api/accounts/{id}/subscriptions
+    [HttpGet("{id}/subscriptions")]
+    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(AccountSubscriptionsViewItem))]
+    [ProducesResponseType(StatusCodes.Status403Forbidden, Type = typeof(ErrMessage))]
+    [ProducesResponseType(StatusCodes.Status404NotFound, Type = typeof(ErrMessage))]
+    public async Task<ActionResult<AccountSubscriptionsViewItem>> GetSubscriptions(int id, CancellationToken ct = default)
+    {
+        var user = await CurrentUser();
+        if (user == null) return _403();
+
+        var account = await _db.Accounts
+            .AsNoTracking()
+            .Include(a => a.UserAccounts)
+            .Include(a => a.Subscriptions)
+                .ThenInclude(s => s.Category)
+            .FirstOrDefaultAsync(a => a.Id == id, ct);
+        if (account == null) return _404Account(id);
+
+        if (!user.IsAdministrator() && !_userInformationService.ManagerOwnsAccount(user, account)) return _403();
+
+        var subscribedCategoryIds = account.Subscriptions.Select(s => s.CategoryId).ToHashSet();
+        var availableCategories = await _db.Categories
+            .AsNoTracking()
+            .Where(c => !c.Free && !subscribedCategoryIds.Contains(c.Id))
+            .OrderBy(c => c.Title)
+            .ToListAsync(ct);
+
+        return new AccountSubscriptionsViewItem
+        {
+            Subscriptions = account.Subscriptions
+                .Where(s => !s.Category.Free)
+                .OrderBy(s => s.Category.Title)
+                .Select(s => new SubscriptionViewItem(s, _subscriptionTimeService))
+                .ToList(),
+            AvailableCategories = availableCategories.Select(c => c.ToViewItem()).ToList()
+        };
+    }
+
+    // PUT: api/accounts/{id}/subscriptions/{categoryId}
+    [HttpPut("{id}/subscriptions/{categoryId}")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest, Type = typeof(ErrMessage))]
+    [ProducesResponseType(StatusCodes.Status403Forbidden, Type = typeof(ErrMessage))]
+    [ProducesResponseType(StatusCodes.Status404NotFound, Type = typeof(ErrMessage))]
+    [ProducesResponseType(StatusCodes.Status409Conflict, Type = typeof(PlaylistAccessImpact))]
+    public async Task<IActionResult> UpsertSubscription(
+        int id,
+        int categoryId,
+        SubscriptionUpsertItem item,
+        CancellationToken ct = default)
+    {
+        var user = await CurrentUser();
+        if (user == null || !user.IsAdministrator()) return _403();
+        if (item.EndDate < item.StartDate) return _400SubscriptionDateRangeInvalid();
+
+        var accountExists = await _db.Accounts.AsNoTracking().AnyAsync(a => a.Id == id, ct);
+        if (!accountExists) return _404Account(id);
+
+        var category = await _db.Categories.AsNoTracking().FirstOrDefaultAsync(c => c.Id == categoryId, ct);
+        if (category == null) return _404Category(categoryId);
+        if (category.Free) return _400SubscriptionCategoryFree(categoryId);
+
+        var startUtc = _subscriptionTimeService.ToUtcStart(item.StartDate);
+        var endUtc = _subscriptionTimeService.ToUtcEnd(item.EndDate);
+
+        var impact = await _playlistAccessService.BuildSubscriptionChangeImpactAsync(id, categoryId, startUtc, endUtc, ct);
+        if (impact.HasImpact && !item.ForcePlaylistCleanup)
+        {
+            return StatusCode(StatusCodes.Status409Conflict, impact);
+        }
+
+        var subscription = await _db.Subscriptions
+            .FirstOrDefaultAsync(s => s.AccountId == id && s.CategoryId == categoryId, ct);
+
+        if (subscription == null)
+        {
+            subscription = new Subscription
+            {
+                AccountId = id,
+                CategoryId = categoryId,
+                StartTime = startUtc,
+                EndTime = endUtc
+            };
+            _db.Subscriptions.Add(subscription);
+        }
+        else
+        {
+            subscription.StartTime = startUtc;
+            subscription.EndTime = endUtc;
+        }
+
+        if (item.ForcePlaylistCleanup && impact.HasImpact)
+        {
+            await _playlistAccessService.RemovePlaylistItemsAsync(impact.VideoPlaylistIds, ct);
+        }
+        else
+        {
+            await _db.SaveChangesAsync(ct);
+        }
+
+        return NoContent();
     }
 
     // POST: api/accounts

--- a/MediaPi.Core/Controllers/CategoriesController.cs
+++ b/MediaPi.Core/Controllers/CategoriesController.cs
@@ -6,6 +6,7 @@ using MediaPi.Core.Data;
 using MediaPi.Core.Extensions;
 using MediaPi.Core.Models;
 using MediaPi.Core.RestModels;
+using MediaPi.Core.Services.Interfaces;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 
@@ -18,9 +19,11 @@ namespace MediaPi.Core.Controllers;
 [ProducesResponseType(StatusCodes.Status401Unauthorized, Type = typeof(ErrMessage))]
 public class CategoriesController(
     IHttpContextAccessor httpContextAccessor,
+    IPlaylistAccessService playlistAccessService,
     AppDbContext db,
     ILogger<CategoriesController> logger) : MediaPiControllerBase(httpContextAccessor, db, logger)
 {
+    private readonly IPlaylistAccessService _playlistAccessService = playlistAccessService;
     private const string CategoryTitleIndex = "IX_categories_title";
     private const string VideoCategoryForeignKey = "FK_videos_categories_category_id";
     private const string SubscriptionCategoryForeignKey = "FK_subscriptions_categories_category_id";
@@ -101,10 +104,27 @@ public class CategoriesController(
         var category = await _db.Categories.FirstOrDefaultAsync(c => c.Id == id, ct);
         if (category == null) return _404Category(id);
 
+        PlaylistAccessImpact? impact = null;
+        if (item.Free.HasValue && item.Free.Value != category.Free)
+        {
+            impact = await _playlistAccessService.BuildCategoryFreeChangeImpactAsync(id, item.Free.Value, ct);
+            if (impact.HasImpact && !item.ForcePlaylistCleanup)
+            {
+                return StatusCode(StatusCodes.Status409Conflict, impact);
+            }
+        }
+
         category.UpdateFrom(item);
         try
         {
-            await _db.SaveChangesAsync(ct);
+            if (item.ForcePlaylistCleanup && impact?.HasImpact == true)
+            {
+                await _playlistAccessService.RemovePlaylistItemsAsync(impact.VideoPlaylistIds, ct);
+            }
+            else
+            {
+                await _db.SaveChangesAsync(ct);
+            }
         }
         catch (DbUpdateException ex) when (IsCategoryTitleConstraint(ex))
         {

--- a/MediaPi.Core/Controllers/DeviceSyncController.cs
+++ b/MediaPi.Core/Controllers/DeviceSyncController.cs
@@ -21,12 +21,14 @@ public class DeviceSyncController(
     IHttpContextAccessor httpContextAccessor,
     IVideoStorageService videoStorageService,
     IScreenshotStorageService screenshotStorageService,
+    IPlaylistAccessService playlistAccessService,
     AppDbContext db,
     ILogger<DeviceSyncController> logger) : MediaPiControllerPreBase(db, logger)
 {
     private readonly IHttpContextAccessor _httpContextAccessor = httpContextAccessor;
     private readonly IVideoStorageService _videoStorageService = videoStorageService;
     private readonly IScreenshotStorageService _screenshotStorageService = screenshotStorageService;
+    private readonly IPlaylistAccessService _playlistAccessService = playlistAccessService;
 
     [HttpGet]
     [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(IEnumerable<DeviceSyncManifestItem>))]
@@ -49,19 +51,34 @@ public class DeviceSyncController(
 
         var deviceGroupId = device.DeviceGroupId.Value;
 
-        var videos = await _db.VideoPlaylists.AsNoTracking()
+        var playlistVideos = await _db.VideoPlaylists.AsNoTracking()
             .Where(vp => vp.Playlist.PlaylistDeviceGroups.Any(pdg => pdg.DeviceGroupId == deviceGroupId))
             .Select(vp => new
             {
                 vp.Video.Id,
                 vp.Video.Filename,
                 vp.Video.FileSizeBytes,
-                vp.Video.Sha256
+                vp.Video.Sha256,
+                vp.Playlist.AccountId
             })
+            .ToListAsync(ct);
+
+        var accessibleVideoIds = new HashSet<int>();
+        foreach (var accountGroup in playlistVideos.GroupBy(video => video.AccountId))
+        {
+            var ids = await _playlistAccessService.GetAccessibleVideoIdsForAccountAsync(
+                accountGroup.Key,
+                accountGroup.Select(video => video.Id),
+                ct);
+            accessibleVideoIds.UnionWith(ids);
+        }
+
+        var videos = playlistVideos
+            .Where(video => accessibleVideoIds.Contains(video.Id))
             // Videos can appear in multiple playlists; group by Video.Id to deduplicate per video.
             .GroupBy(video => video.Id)
             .Select(g => g.First())
-            .ToListAsync(ct);
+            .ToList();
 
         // Despite Video.Filename being marked as 'required', we validate it here as a safety net
         // against potential data integrity issues (e.g., database migration problems, manual data edits).
@@ -204,9 +221,22 @@ public class DeviceSyncController(
         }
         else
         {
-            isAuthorized = await _db.VideoPlaylists.AsNoTracking()
-                .AnyAsync(vp => vp.VideoId == id && 
-                               vp.Playlist.PlaylistDeviceGroups.Any(pdg => pdg.DeviceGroupId == device.DeviceGroupId.Value), ct);
+            var accountIds = await _db.VideoPlaylists.AsNoTracking()
+                .Where(vp => vp.VideoId == id &&
+                             vp.Playlist.PlaylistDeviceGroups.Any(pdg => pdg.DeviceGroupId == device.DeviceGroupId.Value))
+                .Select(vp => vp.Playlist.AccountId)
+                .Distinct()
+                .ToListAsync(ct);
+
+            isAuthorized = false;
+            foreach (var accountId in accountIds)
+            {
+                if (await _playlistAccessService.AccountCanAccessVideoAsync(accountId, id, ct))
+                {
+                    isAuthorized = true;
+                    break;
+                }
+            }
         }
 
         if (!isAuthorized)
@@ -253,7 +283,13 @@ public class DeviceSyncController(
         }
 
         // Get videos ordered by position
+        var accessibleIds = await _playlistAccessService.GetAccessibleVideoIdsForAccountAsync(
+            playlistWithPlay.Playlist.AccountId,
+            playlistWithPlay.Playlist.VideosPlaylist.Select(vp => vp.VideoId),
+            ct);
+
         var videos = playlistWithPlay.Playlist.VideosPlaylist
+            .Where(vp => accessibleIds.Contains(vp.VideoId))
             .OrderBy(vp => vp.Position)
             .Select(vp => vp.Video.Filename)
             .ToList();

--- a/MediaPi.Core/Controllers/MediaPiControllerBase.cs
+++ b/MediaPi.Core/Controllers/MediaPiControllerBase.cs
@@ -145,6 +145,12 @@ public class MediaPiControllerPreBase(AppDbContext db, ILogger logger) : Control
                           new ErrMessage { Msg = $"Видео [id={videoId}] не относится к лицевому счёту [id={accountId}]" });
     }
 
+    protected ObjectResult _400PlaylistVideoAccessDenied(int videoId, int accountId)
+    {
+        return StatusCode(StatusCodes.Status400BadRequest,
+                          new ErrMessage { Msg = $"Видео [id={videoId}] недоступно для плейлиста лицевого счёта [id={accountId}] по условиям подписки" });
+    }
+
     protected ObjectResult _400VideoPlaylistAccountMismatch(int playlistId, int accountId)
     {
         return StatusCode(StatusCodes.Status400BadRequest,
@@ -205,6 +211,18 @@ public class MediaPiControllerPreBase(AppDbContext db, ILogger logger) : Control
     {
         return StatusCode(StatusCodes.Status400BadRequest,
                           new ErrMessage { Msg = "Не указана категория видеофайла" });
+    }
+
+    protected ObjectResult _400SubscriptionDateRangeInvalid()
+    {
+        return StatusCode(StatusCodes.Status400BadRequest,
+                          new ErrMessage { Msg = "Дата окончания подписки не может быть раньше даты начала" });
+    }
+
+    protected ObjectResult _400SubscriptionCategoryFree(int categoryId)
+    {
+        return StatusCode(StatusCodes.Status400BadRequest,
+                          new ErrMessage { Msg = $"Категория [id={categoryId}] доступна без подписки" });
     }
 
     protected ObjectResult _400RequestPayloadMissing()

--- a/MediaPi.Core/Controllers/PlaylistsController.cs
+++ b/MediaPi.Core/Controllers/PlaylistsController.cs
@@ -23,10 +23,12 @@ namespace MediaPi.Core.Controllers;
 public class PlaylistsController(
     IHttpContextAccessor httpContextAccessor,
     IUserInformationService userInformationService,
+    IPlaylistAccessService playlistAccessService,
     AppDbContext db,
     ILogger<PlaylistsController> logger) : MediaPiControllerBase(httpContextAccessor, db, logger)
 {
     private readonly IUserInformationService _userInformationService = userInformationService;
+    private readonly IPlaylistAccessService _playlistAccessService = playlistAccessService;
 
     // GET: api/playlists
     [HttpGet]
@@ -275,6 +277,12 @@ public class PlaylistsController(
         if (mismatch != null)
         {
             return _400PlaylistVideoAccountMismatch(mismatch.Id, accountId);
+        }
+
+        var inaccessibleVideoIds = await _playlistAccessService.GetInaccessibleVideoIdsForAccountAsync(accountId, videoIds, ct);
+        if (inaccessibleVideoIds.Count > 0)
+        {
+            return _400PlaylistVideoAccessDenied(inaccessibleVideoIds[0], accountId);
         }
 
         return null;

--- a/MediaPi.Core/Controllers/VideosController.cs
+++ b/MediaPi.Core/Controllers/VideosController.cs
@@ -25,11 +25,13 @@ public class VideosController(
     IHttpContextAccessor httpContextAccessor,
     IUserInformationService userInformationService,
     IVideoStorageService videoStorageService,
+    IPlaylistAccessService playlistAccessService,
     AppDbContext db,
     ILogger<VideosController> logger) : MediaPiControllerBase(httpContextAccessor, db, logger)
 {
     private readonly IUserInformationService _userInformationService = userInformationService;
     private readonly IVideoStorageService _videoStorageService = videoStorageService;
+    private readonly IPlaylistAccessService _playlistAccessService = playlistAccessService;
 
     [HttpGet]
     [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(IEnumerable<VideoViewItem>))]
@@ -68,6 +70,7 @@ public class VideosController(
     public async Task<ActionResult<IEnumerable<VideoViewItem>>> GetVideosByAccount(
         int accountId,
         [FromQuery] int? categoryId = null,
+        [FromQuery] int? availableForAccountId = null,
         CancellationToken ct = default)
     {
         var user = await CurrentUser();
@@ -75,6 +78,13 @@ public class VideosController(
 
         if (accountId == 0)
         {
+            if (availableForAccountId.HasValue)
+            {
+                var playlistAccount = await _db.Accounts.AsNoTracking().AnyAsync(a => a.Id == availableForAccountId.Value, ct);
+                if (!playlistAccount) return _404Account(availableForAccountId.Value);
+                if (!_userInformationService.UserCanManageAccount(user, availableForAccountId.Value)) return _403();
+            }
+
             var categoryError = await ValidateCategory(categoryId, ct);
             if (categoryError != null) return categoryError;
 
@@ -85,7 +95,17 @@ public class VideosController(
                 query = query.Where(v => v.CategoryId == normalizedCategoryId);
             }
 
-            return await query.Select(v => v.ToViewItem()).ToListAsync(ct);
+            var videos = await query.Select(v => v.ToViewItem()).ToListAsync(ct);
+            if (availableForAccountId.HasValue && videos.Count > 0)
+            {
+                var accessibleIds = await _playlistAccessService.GetAccessibleVideoIdsForAccountAsync(
+                    availableForAccountId.Value,
+                    videos.Select(v => v.Id),
+                    ct);
+                videos = videos.Where(v => accessibleIds.Contains(v.Id)).ToList();
+            }
+
+            return videos;
         }
 
         if (ResolveCategoryId(categoryId) != null) return _400VideoCategoryOnlyForCommon();
@@ -248,7 +268,22 @@ public class VideosController(
             var categoryError = await ValidateVideoCategoryUpdate(video, item.CategoryId.Value, ct);
             if (categoryError != null) return categoryError;
 
-            video.CategoryId = NormalizeCategoryId(item.CategoryId.Value);
+            var normalizedCategoryId = NormalizeCategoryId(item.CategoryId.Value);
+            PlaylistAccessImpact? impact = null;
+            if (video.CategoryId != normalizedCategoryId)
+            {
+                impact = await _playlistAccessService.BuildVideoCategoryChangeImpactAsync([video.Id], normalizedCategoryId, ct);
+                if (impact.HasImpact && !item.ForcePlaylistCleanup)
+                {
+                    return StatusCode(StatusCodes.Status409Conflict, impact);
+                }
+            }
+
+            video.CategoryId = normalizedCategoryId;
+            if (item.ForcePlaylistCleanup && impact?.HasImpact == true)
+            {
+                await _playlistAccessService.RemovePlaylistItemsAsync(impact.VideoPlaylistIds, ct);
+            }
         }
 
         await _db.SaveChangesAsync(ct);
@@ -281,6 +316,7 @@ public class VideosController(
             .ToListAsync(ct);
         var videosById = videos.ToDictionary(v => v.Id);
         var normalizedCategoryId = NormalizeCategoryId(item.CategoryId.Value);
+        var videosToUpdate = new List<Video>();
 
         foreach (var id in ids)
         {
@@ -317,8 +353,30 @@ public class VideosController(
                 continue;
             }
 
-            video.CategoryId = normalizedCategoryId;
+            videosToUpdate.Add(video);
             result.UpdatedIds.Add(video.Id);
+        }
+
+        if (videosToUpdate.Count != 0)
+        {
+            var impact = await _playlistAccessService.BuildVideoCategoryChangeImpactAsync(
+                videosToUpdate.Select(v => v.Id),
+                normalizedCategoryId,
+                ct);
+            if (impact.HasImpact && !item.ForcePlaylistCleanup)
+            {
+                return StatusCode(StatusCodes.Status409Conflict, impact);
+            }
+
+            foreach (var video in videosToUpdate)
+            {
+                video.CategoryId = normalizedCategoryId;
+            }
+
+            if (item.ForcePlaylistCleanup && impact.HasImpact)
+            {
+                await _playlistAccessService.RemovePlaylistItemsAsync(impact.VideoPlaylistIds, ct);
+            }
         }
 
         if (result.UpdatedIds.Count != 0)

--- a/MediaPi.Core/Migrations/20260531220534_0_10_0_Categories.Designer.cs
+++ b/MediaPi.Core/Migrations/20260531220534_0_10_0_Categories.Designer.cs
@@ -12,7 +12,7 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace MediaPi.Core.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    [Migration("20260525215842_0_10_0_Categories")]
+    [Migration("20260531220534_0_10_0_Categories")]
     partial class _0_10_0_Categories
     {
         /// <inheritdoc />
@@ -362,11 +362,6 @@ namespace MediaPi.Core.Migrations
                     b.Property<DateTime>("EndTime")
                         .HasColumnType("timestamp with time zone")
                         .HasColumnName("end_time");
-
-                    b.Property<string>("Name")
-                        .IsRequired()
-                        .HasColumnType("text")
-                        .HasColumnName("name");
 
                     b.Property<DateTime>("StartTime")
                         .HasColumnType("timestamp with time zone")

--- a/MediaPi.Core/Migrations/20260531220534_0_10_0_Categories.cs
+++ b/MediaPi.Core/Migrations/20260531220534_0_10_0_Categories.cs
@@ -18,6 +18,10 @@ namespace MediaPi.Core.Migrations
                 name: "FK_videos_categories_category_id",
                 table: "videos");
 
+            migrationBuilder.DropColumn(
+                name: "name",
+                table: "subscriptions");
+
             migrationBuilder.AddColumn<bool>(
                 name: "free",
                 table: "categories",
@@ -66,6 +70,13 @@ namespace MediaPi.Core.Migrations
             migrationBuilder.DropColumn(
                 name: "free",
                 table: "categories");
+
+            migrationBuilder.AddColumn<string>(
+                name: "name",
+                table: "subscriptions",
+                type: "text",
+                nullable: false,
+                defaultValue: "");
 
             migrationBuilder.AddForeignKey(
                 name: "FK_subscriptions_categories_category_id",

--- a/MediaPi.Core/Migrations/20260531225020_0_11_0_SubscriptionAccess.Designer.cs
+++ b/MediaPi.Core/Migrations/20260531225020_0_11_0_SubscriptionAccess.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using MediaPi.Core.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace MediaPi.Core.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260531225020_0_11_0_SubscriptionAccess")]
+    partial class _0_11_0_SubscriptionAccess
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/MediaPi.Core/Migrations/20260531225020_0_11_0_SubscriptionAccess.cs
+++ b/MediaPi.Core/Migrations/20260531225020_0_11_0_SubscriptionAccess.cs
@@ -1,0 +1,51 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace MediaPi.Core.Migrations
+{
+    /// <inheritdoc />
+    public partial class _0_11_0_SubscriptionAccess : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_subscriptions_account_id",
+                table: "subscriptions");
+
+            migrationBuilder.Sql("""
+                WITH ranked AS (
+                    SELECT
+                        id,
+                        ROW_NUMBER() OVER (
+                            PARTITION BY account_id, category_id
+                            ORDER BY end_time DESC, start_time DESC, id DESC
+                        ) AS rn
+                    FROM subscriptions
+                )
+                DELETE FROM subscriptions
+                WHERE id IN (SELECT id FROM ranked WHERE rn > 1);
+                """);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_subscriptions_account_id_category_id",
+                table: "subscriptions",
+                columns: new[] { "account_id", "category_id" },
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_subscriptions_account_id_category_id",
+                table: "subscriptions");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_subscriptions_account_id",
+                table: "subscriptions",
+                column: "account_id");
+        }
+    }
+}

--- a/MediaPi.Core/Models/Subscription.cs
+++ b/MediaPi.Core/Models/Subscription.cs
@@ -2,17 +2,16 @@
 // This file is a part of Media Pi backend
 
 using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.EntityFrameworkCore;
 
 namespace MediaPi.Core.Models
 {
+    [Index(nameof(AccountId), nameof(CategoryId), IsUnique = true)]
     [Table("subscriptions")]
     public class Subscription
     {
         [Column("id")]
         public int Id { get; set; }
-
-        [Column("name")]
-        public required string Name { get; set; }
 
         [Column("start_time")]
         public DateTime StartTime { get; set; }

--- a/MediaPi.Core/Program.cs
+++ b/MediaPi.Core/Program.cs
@@ -46,9 +46,13 @@ builder.Services
     .Configure<AppSettings>(config.GetSection("AppSettings"))
     .Configure<VideoStorageSettings>(config.GetSection("VideoStorage"))
     .Configure<ScreenshotStorageSettings>(config.GetSection("ScreenshotStorage"))
+    .Configure<SubscriptionSettings>(config.GetSection("SubscriptionSettings"))
     .Configure<DeviceMonitorSettings>(config.GetSection("DeviceMonitoringSettings"))
     .AddScoped<IJwtUtils, JwtUtils>()
     .AddScoped<IUserInformationService, UserInformationService>()
+    .AddSingleton<ISubscriptionTimeService, SubscriptionTimeService>()
+    .AddScoped<IPlaylistAccessService, PlaylistAccessService>()
+    .AddSingleton<ISubscriptionClock, SubscriptionClock>()
     .AddHttpContextAccessor()
     .AddControllers()
     .AddJsonOptions(options =>
@@ -97,6 +101,8 @@ builder.Services.AddSingleton<DeviceEventsService>();
 builder.Services.AddSingleton<DeviceMonitoringService>();
 builder.Services.AddSingleton<IDeviceMonitoringService>(sp => sp.GetRequiredService<DeviceMonitoringService>());
 builder.Services.AddHostedService(sp => sp.GetRequiredService<DeviceMonitoringService>());
+builder.Services.AddSingleton<SubscriptionMaintenanceService>();
+builder.Services.AddHostedService(sp => sp.GetRequiredService<SubscriptionMaintenanceService>());
 builder.Services.AddSingleton<IVideoMetadataService, VideoMetadataService>();
 builder.Services.AddSingleton<IFileStorageService>(sp =>
 {

--- a/MediaPi.Core/RestModels/CategoryUpdateItem.cs
+++ b/MediaPi.Core/RestModels/CategoryUpdateItem.cs
@@ -10,6 +10,7 @@ public class CategoryUpdateItem
 {
     public string? Title { get; set; }
     public bool? Free { get; set; }
+    public bool ForcePlaylistCleanup { get; set; }
 
     public override string ToString()
     {

--- a/MediaPi.Core/RestModels/PlaylistAccessImpact.cs
+++ b/MediaPi.Core/RestModels/PlaylistAccessImpact.cs
@@ -1,0 +1,41 @@
+// Copyright (C) 2025-2026 sw.consulting
+// This file is a part of Media Pi backend
+
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using MediaPi.Core.Settings;
+
+namespace MediaPi.Core.RestModels;
+
+public class PlaylistAccessImpact
+{
+    public int AffectedPlaylistCount { get; init; }
+    public int AffectedItemCount { get; init; }
+    public int AffectedVideoCount { get; init; }
+    public List<AffectedPlaylistItem> AffectedPlaylists { get; init; } = [];
+
+    [JsonIgnore]
+    public List<int> VideoPlaylistIds { get; init; } = [];
+
+    public bool HasImpact => AffectedItemCount > 0;
+
+    public override string ToString() => JsonSerializer.Serialize(this, JOptions.DefaultOptions);
+}
+
+public class AffectedPlaylistItem
+{
+    public int PlaylistId { get; init; }
+    public string Title { get; init; } = string.Empty;
+    public string Filename { get; init; } = string.Empty;
+    public int AccountId { get; init; }
+    public string AccountName { get; init; } = string.Empty;
+    public int RemovedItemCount { get; init; }
+    public int AffectedVideoCount { get; init; }
+}
+
+public class PlaylistCleanupResult
+{
+    public int RemovedItemCount { get; init; }
+    public int AffectedPlaylistCount { get; init; }
+    public int AffectedVideoCount { get; init; }
+}

--- a/MediaPi.Core/RestModels/SubscriptionModels.cs
+++ b/MediaPi.Core/RestModels/SubscriptionModels.cs
@@ -1,0 +1,54 @@
+// Copyright (C) 2025-2026 sw.consulting
+// This file is a part of Media Pi backend
+
+using System.Text.Json;
+using MediaPi.Core.Models;
+using MediaPi.Core.Services.Interfaces;
+using MediaPi.Core.Settings;
+
+namespace MediaPi.Core.RestModels;
+
+public class SubscriptionViewItem
+{
+    public int Id { get; init; }
+    public int AccountId { get; init; }
+    public int CategoryId { get; init; }
+    public string CategoryTitle { get; init; } = string.Empty;
+    public DateOnly StartDate { get; init; }
+    public DateOnly EndDate { get; init; }
+    public bool IsActive { get; init; }
+
+    public SubscriptionViewItem()
+    {
+    }
+
+    public SubscriptionViewItem(Subscription subscription, ISubscriptionTimeService timeService)
+    {
+        Id = subscription.Id;
+        AccountId = subscription.AccountId;
+        CategoryId = subscription.CategoryId;
+        CategoryTitle = subscription.Category?.Title ?? string.Empty;
+        StartDate = timeService.ToLocalDate(subscription.StartTime);
+        EndDate = timeService.ToLocalDate(subscription.EndTime);
+        IsActive = timeService.IsActive(subscription);
+    }
+
+    public override string ToString() => JsonSerializer.Serialize(this, JOptions.DefaultOptions);
+}
+
+public class AccountSubscriptionsViewItem
+{
+    public List<SubscriptionViewItem> Subscriptions { get; init; } = [];
+    public List<CategoryViewItem> AvailableCategories { get; init; } = [];
+
+    public override string ToString() => JsonSerializer.Serialize(this, JOptions.DefaultOptions);
+}
+
+public class SubscriptionUpsertItem
+{
+    public DateOnly StartDate { get; set; }
+    public DateOnly EndDate { get; set; }
+    public bool ForcePlaylistCleanup { get; set; }
+
+    public override string ToString() => JsonSerializer.Serialize(this, JOptions.DefaultOptions);
+}

--- a/MediaPi.Core/RestModels/SubscriptionModels.cs
+++ b/MediaPi.Core/RestModels/SubscriptionModels.cs
@@ -52,3 +52,10 @@ public class SubscriptionUpsertItem
 
     public override string ToString() => JsonSerializer.Serialize(this, JOptions.DefaultOptions);
 }
+
+public class SubscriptionDeleteItem
+{
+    public bool ForcePlaylistCleanup { get; set; }
+
+    public override string ToString() => JsonSerializer.Serialize(this, JOptions.DefaultOptions);
+}

--- a/MediaPi.Core/RestModels/VideoBatchItems.cs
+++ b/MediaPi.Core/RestModels/VideoBatchItems.cs
@@ -28,6 +28,7 @@ public class VideoBatchCategoryUpdateItem
 {
     public List<int> Ids { get; set; } = [];
     public int? CategoryId { get; set; }
+    public bool ForcePlaylistCleanup { get; set; }
 }
 
 public class VideoBatchCategoryUpdateResult

--- a/MediaPi.Core/RestModels/VideoUpdateItem.cs
+++ b/MediaPi.Core/RestModels/VideoUpdateItem.cs
@@ -10,4 +10,6 @@ public class VideoUpdateItem
     public List<int>? PlaylistIds { get; set; }
 
     public int? CategoryId { get; set; }
+
+    public bool ForcePlaylistCleanup { get; set; }
 }

--- a/MediaPi.Core/Services/Interfaces/IPlaylistAccessService.cs
+++ b/MediaPi.Core/Services/Interfaces/IPlaylistAccessService.cs
@@ -1,0 +1,19 @@
+// Copyright (C) 2025-2026 sw.consulting
+// This file is a part of Media Pi backend
+
+using MediaPi.Core.RestModels;
+
+namespace MediaPi.Core.Services.Interfaces;
+
+public interface IPlaylistAccessService
+{
+    Task<IReadOnlySet<int>> GetAccessibleVideoIdsForAccountAsync(int accountId, IEnumerable<int> videoIds, CancellationToken ct = default);
+    Task<IReadOnlyList<int>> GetInaccessibleVideoIdsForAccountAsync(int accountId, IEnumerable<int> videoIds, CancellationToken ct = default);
+    Task<bool> AccountCanAccessVideoAsync(int accountId, int videoId, CancellationToken ct = default);
+    Task<PlaylistAccessImpact> BuildCurrentInvalidPlaylistImpactAsync(CancellationToken ct = default);
+    Task<PlaylistAccessImpact> BuildCategoryFreeChangeImpactAsync(int categoryId, bool proposedFree, CancellationToken ct = default);
+    Task<PlaylistAccessImpact> BuildVideoCategoryChangeImpactAsync(IEnumerable<int> videoIds, int? proposedCategoryId, CancellationToken ct = default);
+    Task<PlaylistAccessImpact> BuildSubscriptionChangeImpactAsync(int accountId, int categoryId, DateTime proposedStartUtc, DateTime proposedEndUtc, CancellationToken ct = default);
+    Task<PlaylistCleanupResult> RemovePlaylistItemsAsync(IEnumerable<int> videoPlaylistIds, CancellationToken ct = default);
+    Task<PlaylistCleanupResult> RemoveCurrentInvalidPlaylistItemsAsync(CancellationToken ct = default);
+}

--- a/MediaPi.Core/Services/Interfaces/ISubscriptionClock.cs
+++ b/MediaPi.Core/Services/Interfaces/ISubscriptionClock.cs
@@ -1,0 +1,9 @@
+// Copyright (C) 2025-2026 sw.consulting
+// This file is a part of Media Pi backend
+
+namespace MediaPi.Core.Services.Interfaces;
+
+public interface ISubscriptionClock
+{
+    DateTime UtcNow { get; }
+}

--- a/MediaPi.Core/Services/Interfaces/ISubscriptionTimeService.cs
+++ b/MediaPi.Core/Services/Interfaces/ISubscriptionTimeService.cs
@@ -1,0 +1,18 @@
+// Copyright (C) 2025-2026 sw.consulting
+// This file is a part of Media Pi backend
+
+using MediaPi.Core.Models;
+
+namespace MediaPi.Core.Services.Interfaces;
+
+public interface ISubscriptionTimeService
+{
+    DateTime UtcNow { get; }
+    DateTime LocalNow { get; }
+    TimeZoneInfo TimeZone { get; }
+    DateTime ToUtcStart(DateOnly localDate);
+    DateTime ToUtcEnd(DateOnly localDate);
+    DateOnly ToLocalDate(DateTime utcDateTime);
+    bool IsActive(Subscription subscription);
+    bool IsActive(DateTime startUtc, DateTime endUtc);
+}

--- a/MediaPi.Core/Services/PlaylistAccessService.cs
+++ b/MediaPi.Core/Services/PlaylistAccessService.cs
@@ -1,0 +1,333 @@
+// Copyright (C) 2025-2026 sw.consulting
+// This file is a part of Media Pi backend
+
+using MediaPi.Core.Data;
+using MediaPi.Core.RestModels;
+using MediaPi.Core.Services.Interfaces;
+using Microsoft.EntityFrameworkCore;
+
+namespace MediaPi.Core.Services;
+
+public class PlaylistAccessService(AppDbContext db, ISubscriptionTimeService timeService) : IPlaylistAccessService
+{
+    private readonly AppDbContext _db = db;
+    private readonly ISubscriptionTimeService _timeService = timeService;
+
+    public async Task<IReadOnlySet<int>> GetAccessibleVideoIdsForAccountAsync(
+        int accountId,
+        IEnumerable<int> videoIds,
+        CancellationToken ct = default)
+    {
+        var ids = videoIds.Distinct().ToList();
+        if (ids.Count == 0) return new HashSet<int>();
+
+        var videos = await _db.Videos
+            .AsNoTracking()
+            .Where(v => ids.Contains(v.Id))
+            .Select(v => new VideoAccessRecord(
+                v.Id,
+                v.AccountId,
+                v.CategoryId,
+                v.Category != null && v.Category.Free))
+            .ToListAsync(ct);
+
+        var categoryIds = videos
+            .Where(v => v.AccountId == null && v.CategoryId.HasValue && !v.CategoryFree)
+            .Select(v => v.CategoryId!.Value)
+            .Distinct()
+            .ToList();
+        var activeSubscriptions = await GetActiveSubscriptionKeysAsync([accountId], categoryIds, ct);
+
+        return videos
+            .Where(v => IsVideoAccessible(v, accountId, activeSubscriptions))
+            .Select(v => v.VideoId)
+            .ToHashSet();
+    }
+
+    public async Task<IReadOnlyList<int>> GetInaccessibleVideoIdsForAccountAsync(
+        int accountId,
+        IEnumerable<int> videoIds,
+        CancellationToken ct = default)
+    {
+        var ids = videoIds.Distinct().ToList();
+        if (ids.Count == 0) return [];
+
+        var accessible = await GetAccessibleVideoIdsForAccountAsync(accountId, ids, ct);
+        return ids.Where(id => !accessible.Contains(id)).ToList();
+    }
+
+    public async Task<bool> AccountCanAccessVideoAsync(int accountId, int videoId, CancellationToken ct = default)
+    {
+        var accessible = await GetAccessibleVideoIdsForAccountAsync(accountId, [videoId], ct);
+        return accessible.Contains(videoId);
+    }
+
+    public async Task<PlaylistAccessImpact> BuildCurrentInvalidPlaylistImpactAsync(CancellationToken ct = default)
+    {
+        var entries = await LoadPlaylistEntriesAsync(null, ct);
+        return await BuildImpactAsync(entries, new AccessOverrides(), ct);
+    }
+
+    public async Task<PlaylistAccessImpact> BuildCategoryFreeChangeImpactAsync(
+        int categoryId,
+        bool proposedFree,
+        CancellationToken ct = default)
+    {
+        var entries = await LoadPlaylistEntriesAsync(entry => entry.CategoryId == categoryId, ct);
+        return await BuildImpactAsync(entries, new AccessOverrides
+        {
+            CategoryFreeOverrides = new Dictionary<int, bool> { [categoryId] = proposedFree }
+        }, ct);
+    }
+
+    public async Task<PlaylistAccessImpact> BuildVideoCategoryChangeImpactAsync(
+        IEnumerable<int> videoIds,
+        int? proposedCategoryId,
+        CancellationToken ct = default)
+    {
+        var ids = videoIds.Distinct().ToList();
+        if (ids.Count == 0) return EmptyImpact();
+
+        var entries = await LoadPlaylistEntriesAsync(entry => ids.Contains(entry.VideoId), ct);
+        var categoryFreeOverrides = new Dictionary<int, bool>();
+        if (proposedCategoryId.HasValue)
+        {
+            var proposedCategory = await _db.Categories
+                .AsNoTracking()
+                .Where(c => c.Id == proposedCategoryId.Value)
+                .Select(c => new { c.Id, c.Free })
+                .SingleAsync(ct);
+            categoryFreeOverrides[proposedCategory.Id] = proposedCategory.Free;
+        }
+
+        return await BuildImpactAsync(entries, new AccessOverrides
+        {
+            VideoCategoryOverrides = ids.ToDictionary(id => id, _ => proposedCategoryId),
+            CategoryFreeOverrides = categoryFreeOverrides
+        }, ct);
+    }
+
+    public async Task<PlaylistAccessImpact> BuildSubscriptionChangeImpactAsync(
+        int accountId,
+        int categoryId,
+        DateTime proposedStartUtc,
+        DateTime proposedEndUtc,
+        CancellationToken ct = default)
+    {
+        var entries = await LoadPlaylistEntriesAsync(
+            entry => entry.PlaylistAccountId == accountId && entry.CategoryId == categoryId,
+            ct);
+
+        return await BuildImpactAsync(entries, new AccessOverrides
+        {
+            SubscriptionActiveOverrides = new Dictionary<(int AccountId, int CategoryId), bool>
+            {
+                [(accountId, categoryId)] = _timeService.IsActive(proposedStartUtc, proposedEndUtc)
+            }
+        }, ct);
+    }
+
+    public async Task<PlaylistCleanupResult> RemoveCurrentInvalidPlaylistItemsAsync(CancellationToken ct = default)
+    {
+        var impact = await BuildCurrentInvalidPlaylistImpactAsync(ct);
+        return await RemovePlaylistItemsAsync(impact.VideoPlaylistIds, ct);
+    }
+
+    public async Task<PlaylistCleanupResult> RemovePlaylistItemsAsync(IEnumerable<int> videoPlaylistIds, CancellationToken ct = default)
+    {
+        var ids = videoPlaylistIds.Distinct().ToList();
+        if (ids.Count == 0)
+        {
+            return new PlaylistCleanupResult();
+        }
+
+        var rows = await _db.VideoPlaylists
+            .Where(vp => ids.Contains(vp.Id))
+            .Select(vp => new { vp.Id, vp.PlaylistId, vp.VideoId })
+            .ToListAsync(ct);
+        if (rows.Count == 0)
+        {
+            return new PlaylistCleanupResult();
+        }
+
+        var rowIds = rows.Select(row => row.Id).ToList();
+        var entities = await _db.VideoPlaylists
+            .Where(vp => rowIds.Contains(vp.Id))
+            .ToListAsync(ct);
+        _db.VideoPlaylists.RemoveRange(entities);
+        await _db.SaveChangesAsync(ct);
+
+        return new PlaylistCleanupResult
+        {
+            RemovedItemCount = rows.Count,
+            AffectedPlaylistCount = rows.Select(row => row.PlaylistId).Distinct().Count(),
+            AffectedVideoCount = rows.Select(row => row.VideoId).Distinct().Count()
+        };
+    }
+
+    private async Task<PlaylistAccessImpact> BuildImpactAsync(
+        IReadOnlyList<PlaylistEntryRecord> entries,
+        AccessOverrides overrides,
+        CancellationToken ct)
+    {
+        if (entries.Count == 0) return EmptyImpact();
+
+        var accountIds = entries.Select(entry => entry.PlaylistAccountId).Distinct().ToList();
+        var categoryIds = entries
+            .Select(entry => ResolveCategoryId(entry, overrides))
+            .Where(categoryId => categoryId.HasValue)
+            .Select(categoryId => categoryId!.Value)
+            .Distinct()
+            .ToList();
+        var activeSubscriptions = await GetActiveSubscriptionKeysAsync(accountIds, categoryIds, ct);
+
+        foreach (var overrideItem in overrides.SubscriptionActiveOverrides)
+        {
+            if (overrideItem.Value)
+            {
+                activeSubscriptions.Add(overrideItem.Key);
+            }
+            else
+            {
+                activeSubscriptions.Remove(overrideItem.Key);
+            }
+        }
+
+        var invalidEntries = entries
+            .Where(entry => !IsEntryAccessible(entry, overrides, activeSubscriptions))
+            .ToList();
+        if (invalidEntries.Count == 0) return EmptyImpact();
+
+        var affectedPlaylists = invalidEntries
+            .GroupBy(entry => new
+            {
+                entry.PlaylistId,
+                entry.PlaylistTitle,
+                entry.PlaylistFilename,
+                entry.PlaylistAccountId,
+                entry.AccountName
+            })
+            .Select(group => new AffectedPlaylistItem
+            {
+                PlaylistId = group.Key.PlaylistId,
+                Title = group.Key.PlaylistTitle,
+                Filename = group.Key.PlaylistFilename,
+                AccountId = group.Key.PlaylistAccountId,
+                AccountName = group.Key.AccountName,
+                RemovedItemCount = group.Count(),
+                AffectedVideoCount = group.Select(entry => entry.VideoId).Distinct().Count()
+            })
+            .OrderBy(item => item.AccountName)
+            .ThenBy(item => item.Title)
+            .ThenBy(item => item.PlaylistId)
+            .ToList();
+
+        return new PlaylistAccessImpact
+        {
+            AffectedPlaylistCount = affectedPlaylists.Count,
+            AffectedItemCount = invalidEntries.Count,
+            AffectedVideoCount = invalidEntries.Select(entry => entry.VideoId).Distinct().Count(),
+            AffectedPlaylists = affectedPlaylists,
+            VideoPlaylistIds = invalidEntries.Select(entry => entry.VideoPlaylistId).Distinct().ToList()
+        };
+    }
+
+    private async Task<HashSet<(int AccountId, int CategoryId)>> GetActiveSubscriptionKeysAsync(
+        IReadOnlyCollection<int> accountIds,
+        IReadOnlyCollection<int> categoryIds,
+        CancellationToken ct)
+    {
+        if (accountIds.Count == 0 || categoryIds.Count == 0) return [];
+
+        var now = _timeService.UtcNow;
+        var subscriptions = await _db.Subscriptions
+            .AsNoTracking()
+            .Where(s => accountIds.Contains(s.AccountId)
+                && categoryIds.Contains(s.CategoryId)
+                && s.StartTime <= now
+                && now <= s.EndTime)
+            .Select(s => new { s.AccountId, s.CategoryId })
+            .ToListAsync(ct);
+
+        return subscriptions.Select(s => (s.AccountId, s.CategoryId)).ToHashSet();
+    }
+
+    private async Task<List<PlaylistEntryRecord>> LoadPlaylistEntriesAsync(
+        Func<PlaylistEntryRecord, bool>? filter,
+        CancellationToken ct)
+    {
+        var entries = await _db.VideoPlaylists
+            .AsNoTracking()
+            .Select(vp => new PlaylistEntryRecord(
+                vp.Id,
+                vp.VideoId,
+                vp.Video.AccountId,
+                vp.Video.CategoryId,
+                vp.Video.Category != null && vp.Video.Category.Free,
+                vp.PlaylistId,
+                vp.Playlist.Title,
+                vp.Playlist.Filename,
+                vp.Playlist.AccountId,
+                vp.Playlist.Account.Name))
+            .ToListAsync(ct);
+
+        return filter == null ? entries : entries.Where(filter).ToList();
+    }
+
+    private static bool IsVideoAccessible(
+        VideoAccessRecord video,
+        int accountId,
+        IReadOnlySet<(int AccountId, int CategoryId)> activeSubscriptions)
+    {
+        if (video.AccountId.HasValue) return video.AccountId.Value == accountId;
+        if (!video.CategoryId.HasValue) return true;
+        return video.CategoryFree || activeSubscriptions.Contains((accountId, video.CategoryId.Value));
+    }
+
+    private static bool IsEntryAccessible(
+        PlaylistEntryRecord entry,
+        AccessOverrides overrides,
+        IReadOnlySet<(int AccountId, int CategoryId)> activeSubscriptions)
+    {
+        if (entry.VideoAccountId.HasValue) return entry.VideoAccountId.Value == entry.PlaylistAccountId;
+
+        var categoryId = ResolveCategoryId(entry, overrides);
+        if (!categoryId.HasValue) return true;
+
+        var categoryFree = ResolveCategoryFree(entry, categoryId.Value, overrides);
+        return categoryFree || activeSubscriptions.Contains((entry.PlaylistAccountId, categoryId.Value));
+    }
+
+    private static int? ResolveCategoryId(PlaylistEntryRecord entry, AccessOverrides overrides) =>
+        overrides.VideoCategoryOverrides.TryGetValue(entry.VideoId, out var categoryId)
+            ? categoryId
+            : entry.CategoryId;
+
+    private static bool ResolveCategoryFree(PlaylistEntryRecord entry, int categoryId, AccessOverrides overrides) =>
+        overrides.CategoryFreeOverrides.TryGetValue(categoryId, out var proposedFree)
+            ? proposedFree
+            : entry.CategoryId == categoryId && entry.CategoryFree;
+
+    private static PlaylistAccessImpact EmptyImpact() => new();
+
+    private sealed record VideoAccessRecord(int VideoId, int? AccountId, int? CategoryId, bool CategoryFree);
+
+    private sealed record PlaylistEntryRecord(
+        int VideoPlaylistId,
+        int VideoId,
+        int? VideoAccountId,
+        int? CategoryId,
+        bool CategoryFree,
+        int PlaylistId,
+        string PlaylistTitle,
+        string PlaylistFilename,
+        int PlaylistAccountId,
+        string AccountName);
+
+    private sealed class AccessOverrides
+    {
+        public Dictionary<int, int?> VideoCategoryOverrides { get; init; } = [];
+        public Dictionary<int, bool> CategoryFreeOverrides { get; init; } = [];
+        public Dictionary<(int AccountId, int CategoryId), bool> SubscriptionActiveOverrides { get; init; } = [];
+    }
+}

--- a/MediaPi.Core/Services/SubscriptionClock.cs
+++ b/MediaPi.Core/Services/SubscriptionClock.cs
@@ -1,0 +1,11 @@
+// Copyright (C) 2025-2026 sw.consulting
+// This file is a part of Media Pi backend
+
+using MediaPi.Core.Services.Interfaces;
+
+namespace MediaPi.Core.Services;
+
+public class SubscriptionClock : ISubscriptionClock
+{
+    public DateTime UtcNow => DateTime.UtcNow;
+}

--- a/MediaPi.Core/Services/SubscriptionMaintenanceService.cs
+++ b/MediaPi.Core/Services/SubscriptionMaintenanceService.cs
@@ -1,0 +1,66 @@
+// Copyright (C) 2025-2026 sw.consulting
+// This file is a part of Media Pi backend
+
+using MediaPi.Core.RestModels;
+using MediaPi.Core.Services.Interfaces;
+
+namespace MediaPi.Core.Services;
+
+public class SubscriptionMaintenanceService(
+    IServiceScopeFactory scopeFactory,
+    ISubscriptionTimeService timeService,
+    ILogger<SubscriptionMaintenanceService> logger) : BackgroundService
+{
+    private readonly IServiceScopeFactory _scopeFactory = scopeFactory;
+    private readonly ISubscriptionTimeService _timeService = timeService;
+    private readonly ILogger<SubscriptionMaintenanceService> _logger = logger;
+
+    public async Task<PlaylistCleanupResult> RunCleanupOnceAsync(CancellationToken ct = default)
+    {
+        using var scope = _scopeFactory.CreateScope();
+        var playlistAccessService = scope.ServiceProvider.GetRequiredService<IPlaylistAccessService>();
+        var result = await playlistAccessService.RemoveCurrentInvalidPlaylistItemsAsync(ct);
+        _logger.LogInformation(
+            "Subscription maintenance removed {RemovedItemCount} playlist items from {AffectedPlaylistCount} playlists for {AffectedVideoCount} videos.",
+            result.RemovedItemCount,
+            result.AffectedPlaylistCount,
+            result.AffectedVideoCount);
+        return result;
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        _logger.LogInformation("SubscriptionMaintenanceService started.");
+
+        try
+        {
+            await RunCleanupOnceAsync(stoppingToken);
+
+            while (!stoppingToken.IsCancellationRequested)
+            {
+                var delay = GetDelayUntilNextLocalMidnight();
+                await Task.Delay(delay, stoppingToken);
+                await RunCleanupOnceAsync(stoppingToken);
+            }
+        }
+        catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+        {
+        }
+        catch (Exception ex)
+        {
+            _logger.LogCritical(ex, "SubscriptionMaintenanceService encountered a fatal error and is stopping.");
+        }
+        finally
+        {
+            _logger.LogInformation("SubscriptionMaintenanceService stopped.");
+        }
+    }
+
+    internal TimeSpan GetDelayUntilNextLocalMidnight()
+    {
+        var localNow = _timeService.LocalNow;
+        var nextLocalMidnight = localNow.Date.AddDays(1);
+        var delay = nextLocalMidnight - localNow;
+        return delay <= TimeSpan.Zero ? TimeSpan.FromSeconds(1) : delay;
+    }
+}

--- a/MediaPi.Core/Services/SubscriptionTimeService.cs
+++ b/MediaPi.Core/Services/SubscriptionTimeService.cs
@@ -1,0 +1,77 @@
+// Copyright (C) 2025-2026 sw.consulting
+// This file is a part of Media Pi backend
+
+using MediaPi.Core.Models;
+using MediaPi.Core.Services.Interfaces;
+using MediaPi.Core.Settings;
+using Microsoft.Extensions.Options;
+
+namespace MediaPi.Core.Services;
+
+public class SubscriptionTimeService : ISubscriptionTimeService
+{
+    private readonly ISubscriptionClock _clock;
+
+    public SubscriptionTimeService(IOptions<SubscriptionSettings> options, ISubscriptionClock clock)
+    {
+        _clock = clock;
+        TimeZone = ResolveTimeZone(options.Value.TimeZoneId);
+    }
+
+    public DateTime UtcNow => EnsureUtc(_clock.UtcNow);
+    public DateTime LocalNow => TimeZoneInfo.ConvertTimeFromUtc(UtcNow, TimeZone);
+    public TimeZoneInfo TimeZone { get; }
+
+    public DateTime ToUtcStart(DateOnly localDate) =>
+        TimeZoneInfo.ConvertTimeToUtc(localDate.ToDateTime(TimeOnly.MinValue), TimeZone);
+
+    public DateTime ToUtcEnd(DateOnly localDate) =>
+        TimeZoneInfo.ConvertTimeToUtc(localDate.ToDateTime(TimeOnly.MinValue).AddDays(1).AddTicks(-1), TimeZone);
+
+    public DateOnly ToLocalDate(DateTime utcDateTime) =>
+        DateOnly.FromDateTime(TimeZoneInfo.ConvertTimeFromUtc(EnsureUtc(utcDateTime), TimeZone));
+
+    public bool IsActive(Subscription subscription) => IsActive(subscription.StartTime, subscription.EndTime);
+
+    public bool IsActive(DateTime startUtc, DateTime endUtc)
+    {
+        var now = UtcNow;
+        return EnsureUtc(startUtc) <= now && now <= EnsureUtc(endUtc);
+    }
+
+    private static DateTime EnsureUtc(DateTime value)
+    {
+        return value.Kind switch
+        {
+            DateTimeKind.Utc => value,
+            DateTimeKind.Local => value.ToUniversalTime(),
+            _ => DateTime.SpecifyKind(value, DateTimeKind.Utc)
+        };
+    }
+
+    private static TimeZoneInfo ResolveTimeZone(string? timeZoneId)
+    {
+        foreach (var id in CandidateTimeZoneIds(timeZoneId))
+        {
+            try
+            {
+                return TimeZoneInfo.FindSystemTimeZoneById(id);
+            }
+            catch (TimeZoneNotFoundException)
+            {
+            }
+            catch (InvalidTimeZoneException)
+            {
+            }
+        }
+
+        return TimeZoneInfo.CreateCustomTimeZone("Europe/Moscow", TimeSpan.FromHours(3), "Europe/Moscow", "Europe/Moscow");
+    }
+
+    private static IEnumerable<string> CandidateTimeZoneIds(string? configured)
+    {
+        if (!string.IsNullOrWhiteSpace(configured)) yield return configured;
+        yield return "Europe/Moscow";
+        yield return "Russian Standard Time";
+    }
+}

--- a/MediaPi.Core/Settings/SubscriptionSettings.cs
+++ b/MediaPi.Core/Settings/SubscriptionSettings.cs
@@ -1,0 +1,9 @@
+// Copyright (C) 2025-2026 sw.consulting
+// This file is a part of Media Pi backend
+
+namespace MediaPi.Core.Settings;
+
+public class SubscriptionSettings
+{
+    public string TimeZoneId { get; set; } = "Europe/Moscow";
+}

--- a/MediaPi.Core/VersionInfo.cs
+++ b/MediaPi.Core/VersionInfo.cs
@@ -5,5 +5,5 @@ namespace MediaPi.Core;
 
 public static class VersionInfo
 {
-    public const string AppVersion = "0.9.1";
+    public const string AppVersion = "0.10.0";
 }

--- a/MediaPi.Core/appsettings.json
+++ b/MediaPi.Core/appsettings.json
@@ -23,6 +23,9 @@
     "RootPath": "/var/lib/storage/screenshots",
     "MaxFilesPerDirectory": 1000
   },
+  "SubscriptionSettings": {
+    "TimeZoneId": "Europe/Moscow"
+  },
   "DeviceMonitoringSettings": {
     "ActiveSubscriberPollingIntervalSeconds": 10,
     "LazyPollingIntervalSeconds": 3600,


### PR DESCRIPTION
Adds subscription/category-based access control for common videos and a maintenance pipeline that prevents/cleans up playlists holding now-inaccessible items. Introduces a configurable subscription timezone (`Europe/Moscow` by default) and subscription management endpoints under `AccountsController`. Bumps app version to `0.10.0`, drops the unused `subscriptions.name` column, and enforces a unique `(account_id, category_id)` index on `subscriptions`.

## Changes

- New `PlaylistAccessService` / `SubscriptionTimeService` / `SubscriptionClock` / `SubscriptionMaintenanceService`, wired through `Program.cs` and a new `SubscriptionSettings` config section.
- Controller integrations: `PlaylistsController` rejects videos inaccessible under a category's subscription rules; `VideosController`, `CategoriesController`, and `AccountsController` add `ForcePlaylistCleanup`/409-impact flows; `DeviceSyncController` filters manifest/download/M3U output by access rules.
- Schema: drops `subscriptions.name`, adds `categories.free`, enforces unique category title and unique `(account_id, category_id)` after dedup migration.

## Testing

Added comprehensive unit tests targeting ≥95% coverage of all new and modified code:

- **`SubscriptionTimeServiceTests`** – all public methods/properties and `SubscriptionClock`
- **`SubscriptionMaintenanceServiceTests`** – `RunCleanupOnceAsync`, `GetDelayUntilNextLocalMidnight`, `ExecuteAsync` cancellation
- **`SubscriptionModelsTests`** – all REST model constructors/`ToString`, `PlaylistAccessImpact`, `PlaylistCleanupResult`
- **`PlaylistAccessServiceTests`** (extended) – `GetInaccessibleVideoIds`, `AccountCanAccessVideo`, impact-build methods, `RemovePlaylistItems` edge cases
- **`AccountsControllerTests`** (extended) – `GetSubscriptions` (200/403/404) and `UpsertSubscription` all branches (400/403/404/409/204 + `ForcePlaylistCleanup`)
- **`VideosControllerTests`** (extended) – `availableForAccountId` filter (200/403/404) and `UpdateVideo`/`UpdateVideoCategories` category-change impact + forced cleanup paths