### PR TITLE
feat: video playback

### DIFF
--- a/MediaPi.Core.Tests/Authorization/VideoPlaybackTokenServiceTests.cs
+++ b/MediaPi.Core.Tests/Authorization/VideoPlaybackTokenServiceTests.cs
@@ -67,6 +67,49 @@ public class VideoPlaybackTokenServiceTests
         Assert.That(userId, Is.Null);
     }
 
+    [Test]
+    public void Constructor_NullSecret_ThrowsException()
+    {
+        Assert.Throws<Exception>(() =>
+            new VideoPlaybackTokenService(
+                Options.Create(new AppSettings { Secret = null, JwtTokenExpirationDays = 7 }),
+                Mock.Of<ILogger<VideoPlaybackTokenService>>()));
+    }
+
+    [Test]
+    public void Constructor_EmptySecret_ThrowsException()
+    {
+        Assert.Throws<Exception>(() =>
+            new VideoPlaybackTokenService(
+                Options.Create(new AppSettings { Secret = string.Empty, JwtTokenExpirationDays = 7 }),
+                Mock.Of<ILogger<VideoPlaybackTokenService>>()));
+    }
+
+    [Test]
+    public void Validate_TokenSignedWithDifferentKey_ReturnsNull()
+    {
+        var service = CreateService();
+        var tokenHandler = new JwtSecurityTokenHandler();
+        var differentKey = SHA256.HashData(Encoding.UTF8.GetBytes("different-secret:video-playback"));
+        var tokenDescriptor = new SecurityTokenDescriptor
+        {
+            Subject = new ClaimsIdentity(new[]
+            {
+                new Claim("id", "7"),
+                new Claim("videoId", "11"),
+                new Claim("purpose", "video-playback")
+            }),
+            Expires = DateTime.UtcNow.AddMinutes(60),
+            SigningCredentials = new SigningCredentials(
+                new SymmetricSecurityKey(differentKey), SecurityAlgorithms.HmacSha256Signature)
+        };
+        var token = tokenHandler.WriteToken(tokenHandler.CreateToken(tokenDescriptor));
+
+        var userId = service.Validate(token, videoId: 11);
+
+        Assert.That(userId, Is.Null);
+    }
+
     private static VideoPlaybackTokenService CreateService()
     {
         return new VideoPlaybackTokenService(

--- a/MediaPi.Core.Tests/Authorization/VideoPlaybackTokenServiceTests.cs
+++ b/MediaPi.Core.Tests/Authorization/VideoPlaybackTokenServiceTests.cs
@@ -70,7 +70,7 @@ public class VideoPlaybackTokenServiceTests
     [Test]
     public void Constructor_NullSecret_ThrowsException()
     {
-        Assert.Throws<Exception>(() =>
+        Assert.Throws<InvalidOperationException>(() =>
             new VideoPlaybackTokenService(
                 Options.Create(new AppSettings { Secret = null, JwtTokenExpirationDays = 7 }),
                 Mock.Of<ILogger<VideoPlaybackTokenService>>()));
@@ -79,7 +79,7 @@ public class VideoPlaybackTokenServiceTests
     [Test]
     public void Constructor_EmptySecret_ThrowsException()
     {
-        Assert.Throws<Exception>(() =>
+        Assert.Throws<InvalidOperationException>(() =>
             new VideoPlaybackTokenService(
                 Options.Create(new AppSettings { Secret = string.Empty, JwtTokenExpirationDays = 7 }),
                 Mock.Of<ILogger<VideoPlaybackTokenService>>()));

--- a/MediaPi.Core.Tests/Authorization/VideoPlaybackTokenServiceTests.cs
+++ b/MediaPi.Core.Tests/Authorization/VideoPlaybackTokenServiceTests.cs
@@ -77,7 +77,7 @@ public class VideoPlaybackTokenServiceTests
     private static string CreateToken(int userId, int videoId, string purpose, DateTime expiresAt)
     {
         var tokenHandler = new JwtSecurityTokenHandler();
-        var key = SHA256.HashData(Encoding.UTF8.GetBytes(Secret));
+        var key = SHA256.HashData(Encoding.UTF8.GetBytes(Secret + ":video-playback"));
         var tokenDescriptor = new SecurityTokenDescriptor
         {
             Subject = new ClaimsIdentity(new[]

--- a/MediaPi.Core.Tests/Authorization/VideoPlaybackTokenServiceTests.cs
+++ b/MediaPi.Core.Tests/Authorization/VideoPlaybackTokenServiceTests.cs
@@ -1,0 +1,97 @@
+// Copyright (C) 2026 sw.consulting
+// This file is a part of Media Pi backend
+
+using MediaPi.Core.Authorization;
+using MediaPi.Core.Settings;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Microsoft.IdentityModel.Tokens;
+using Moq;
+using NUnit.Framework;
+using System;
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+using System.Security.Cryptography;
+using System.Text;
+
+namespace MediaPi.Core.Tests.Authorization;
+
+[TestFixture]
+public class VideoPlaybackTokenServiceTests
+{
+    private const string Secret = "video-playback-test-secret";
+
+    [Test]
+    public void Generate_Validate_ReturnsUserId()
+    {
+        var service = CreateService();
+
+        var token = service.Generate(userId: 7, videoId: 11);
+        var userId = service.Validate(token.Token, videoId: 11);
+
+        Assert.That(userId, Is.EqualTo(7));
+        Assert.That(token.ExpiresAt, Is.GreaterThan(DateTime.UtcNow.AddMinutes(59)));
+        Assert.That(token.ExpiresAt, Is.LessThanOrEqualTo(DateTime.UtcNow.AddMinutes(60)));
+    }
+
+    [Test]
+    public void Validate_WrongVideo_ReturnsNull()
+    {
+        var service = CreateService();
+        var token = service.Generate(userId: 7, videoId: 11);
+
+        var userId = service.Validate(token.Token, videoId: 12);
+
+        Assert.That(userId, Is.Null);
+    }
+
+    [Test]
+    public void Validate_WrongPurpose_ReturnsNull()
+    {
+        var service = CreateService();
+        var token = CreateToken(userId: 7, videoId: 11, purpose: "other-purpose", expiresAt: DateTime.UtcNow.AddMinutes(60));
+
+        var userId = service.Validate(token, videoId: 11);
+
+        Assert.That(userId, Is.Null);
+    }
+
+    [Test]
+    public void Validate_ExpiredToken_ReturnsNull()
+    {
+        var service = CreateService();
+        var token = CreateToken(userId: 7, videoId: 11, purpose: "video-playback", expiresAt: DateTime.UtcNow.AddMinutes(-1));
+
+        var userId = service.Validate(token, videoId: 11);
+
+        Assert.That(userId, Is.Null);
+    }
+
+    private static VideoPlaybackTokenService CreateService()
+    {
+        return new VideoPlaybackTokenService(
+            Options.Create(new AppSettings { Secret = Secret, JwtTokenExpirationDays = 7 }),
+            Mock.Of<ILogger<VideoPlaybackTokenService>>());
+    }
+
+    private static string CreateToken(int userId, int videoId, string purpose, DateTime expiresAt)
+    {
+        var tokenHandler = new JwtSecurityTokenHandler();
+        var key = SHA256.HashData(Encoding.UTF8.GetBytes(Secret));
+        var tokenDescriptor = new SecurityTokenDescriptor
+        {
+            Subject = new ClaimsIdentity(new[]
+            {
+                new Claim("id", userId.ToString()),
+                new Claim("videoId", videoId.ToString()),
+                new Claim("purpose", purpose)
+            }),
+            IssuedAt = DateTime.UtcNow.AddMinutes(-2),
+            NotBefore = DateTime.UtcNow.AddMinutes(-2),
+            Expires = expiresAt,
+            SigningCredentials = new SigningCredentials(new SymmetricSecurityKey(key), SecurityAlgorithms.HmacSha256Signature)
+        };
+        var token = tokenHandler.CreateToken(tokenDescriptor);
+        return tokenHandler.WriteToken(token);
+    }
+}

--- a/MediaPi.Core.Tests/Controllers/VideosControllerTests.cs
+++ b/MediaPi.Core.Tests/Controllers/VideosControllerTests.cs
@@ -9,6 +9,7 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 
+using MediaPi.Core.Authorization;
 using MediaPi.Core.Controllers;
 using MediaPi.Core.Data;
 using MediaPi.Core.Models;
@@ -32,6 +33,7 @@ public class VideosControllerTests
     private Mock<IHttpContextAccessor> _mockHttpContextAccessor;
     private Mock<ILogger<VideosController>> _mockLogger;
     private Mock<IVideoStorageService> _mockVideoStorageService;
+    private Mock<IVideoPlaybackTokenService> _mockVideoPlaybackTokenService;
     private AppDbContext _dbContext;
     private VideosController _controller;
     private UserInformationService _userInformationService;
@@ -121,6 +123,7 @@ public class VideosControllerTests
         _mockHttpContextAccessor = new Mock<IHttpContextAccessor>();
         _mockLogger = new Mock<ILogger<VideosController>>();
         _mockVideoStorageService = new Mock<IVideoStorageService>();
+        _mockVideoPlaybackTokenService = new Mock<IVideoPlaybackTokenService>();
         _userInformationService = new UserInformationService(_dbContext);
     }
 
@@ -138,6 +141,7 @@ public class VideosControllerTests
             _userInformationService,
             _mockVideoStorageService.Object,
             SubscriptionTestServices.PlaylistAccessService(_dbContext),
+            _mockVideoPlaybackTokenService.Object,
             _dbContext,
             _mockLogger.Object)
         {
@@ -197,6 +201,186 @@ public class VideosControllerTests
         var result = await _controller.GetVideo(3);
         Assert.That(result.Value, Is.Not.Null);
         Assert.That(result.Value!.Id, Is.EqualTo(3));
+    }
+
+    [Test]
+    public async Task CreatePlaybackToken_ManagerOwnVideo_ReturnsTokenResponse()
+    {
+        var expiresAt = DateTime.UtcNow.AddMinutes(60);
+        _mockVideoPlaybackTokenService
+            .Setup(s => s.Generate(_managerAccount1.Id, _videoAccount1.Id))
+            .Returns(new VideoPlaybackToken("playback-token", expiresAt));
+        SetCurrentUser(_managerAccount1.Id);
+
+        var result = await _controller.CreatePlaybackToken(_videoAccount1.Id, CancellationToken.None);
+
+        Assert.That(result.Result, Is.TypeOf<OkObjectResult>());
+        var body = (VideoPlaybackTokenViewItem)((OkObjectResult)result.Result!).Value!;
+        Assert.That(body.Token, Is.EqualTo("playback-token"));
+        Assert.That(body.ExpiresAt, Is.EqualTo(expiresAt));
+        Assert.That(body.Url, Is.EqualTo($"/api/videos/{_videoAccount1.Id}/file?playbackToken=playback-token"));
+    }
+
+    [Test]
+    public async Task CreatePlaybackToken_MissingVideo_Returns404()
+    {
+        SetCurrentUser(_admin.Id);
+
+        var result = await _controller.CreatePlaybackToken(999, CancellationToken.None);
+
+        Assert.That(result.Result, Is.TypeOf<ObjectResult>());
+        Assert.That(((ObjectResult)result.Result!).StatusCode, Is.EqualTo(StatusCodes.Status404NotFound));
+        _mockVideoPlaybackTokenService.Verify(s => s.Generate(It.IsAny<int>(), It.IsAny<int>()), Times.Never);
+    }
+
+    [Test]
+    public async Task CreatePlaybackToken_ManagerOtherAccount_Returns403()
+    {
+        SetCurrentUser(_managerAccount1.Id);
+
+        var result = await _controller.CreatePlaybackToken(_videoAccount2.Id, CancellationToken.None);
+
+        Assert.That(result.Result, Is.TypeOf<ObjectResult>());
+        Assert.That(((ObjectResult)result.Result!).StatusCode, Is.EqualTo(StatusCodes.Status403Forbidden));
+        _mockVideoPlaybackTokenService.Verify(s => s.Generate(It.IsAny<int>(), It.IsAny<int>()), Times.Never);
+    }
+
+    [Test]
+    public async Task GetVideoFile_NotFound_Returns404()
+    {
+        SetCurrentUser(_admin.Id);
+
+        var result = await _controller.GetVideoFile(999, ct: CancellationToken.None);
+
+        Assert.That(result, Is.TypeOf<ObjectResult>());
+        var obj = (ObjectResult)result;
+        Assert.That(obj.StatusCode, Is.EqualTo(StatusCodes.Status404NotFound));
+        Assert.That((obj.Value as ErrMessage)?.Msg, Does.Contain("999"));
+    }
+
+    [Test]
+    public async Task GetVideoFile_ManagerOtherAccount_Returns403()
+    {
+        SetCurrentUser(_managerAccount1.Id);
+
+        var result = await _controller.GetVideoFile(_videoAccount2.Id, ct: CancellationToken.None);
+
+        Assert.That(result, Is.TypeOf<ObjectResult>());
+        Assert.That(((ObjectResult)result).StatusCode, Is.EqualTo(StatusCodes.Status403Forbidden));
+        _mockVideoStorageService.Verify(s => s.GetAbsolutePath(It.IsAny<string>()), Times.Never);
+    }
+
+    [Test]
+    public async Task GetVideoFile_ManagerCommonVideo_ReturnsPhysicalFileResult()
+    {
+        var expectedPath = "/storage/0001/public.mp4";
+        _mockVideoStorageService.Setup(s => s.GetAbsolutePath(_videoCommon.Filename)).Returns(expectedPath);
+        SetCurrentUser(_managerAccount1.Id);
+
+        var result = await _controller.GetVideoFile(_videoCommon.Id, ct: CancellationToken.None);
+
+        Assert.That(result, Is.TypeOf<PhysicalFileResult>());
+        var fileResult = (PhysicalFileResult)result;
+        Assert.That(fileResult.FileName, Is.EqualTo(expectedPath));
+        Assert.That(fileResult.ContentType, Is.EqualTo("video/mp4"));
+        Assert.That(fileResult.FileDownloadName, Is.Null.Or.Empty);
+        Assert.That(_controller.Response.Headers["Content-Disposition"].ToString(), Does.Contain("inline"));
+        Assert.That(_controller.Response.Headers["Content-Disposition"].ToString(), Does.Contain(_videoCommon.OriginalFilename));
+    }
+
+    [Test]
+    public async Task GetVideoFile_ValidPlaybackToken_ReturnsPhysicalFileResult()
+    {
+        var expectedPath = "/storage/0001/public.mp4";
+        _mockVideoStorageService.Setup(s => s.GetAbsolutePath(_videoCommon.Filename)).Returns(expectedPath);
+        _mockVideoPlaybackTokenService
+            .Setup(s => s.Validate("valid-token", _videoCommon.Id))
+            .Returns(_managerAccount1.Id);
+        SetCurrentUser(null);
+
+        var result = await _controller.GetVideoFile(_videoCommon.Id, "valid-token", CancellationToken.None);
+
+        Assert.That(result, Is.TypeOf<PhysicalFileResult>());
+        var fileResult = (PhysicalFileResult)result;
+        Assert.That(fileResult.FileName, Is.EqualTo(expectedPath));
+        Assert.That(fileResult.ContentType, Is.EqualTo("video/mp4"));
+        Assert.That(fileResult.FileDownloadName, Is.Null.Or.Empty);
+        Assert.That(_controller.Response.Headers["Content-Disposition"].ToString(), Does.Contain("inline"));
+        Assert.That(_controller.Response.Headers["Content-Disposition"].ToString(), Does.Contain(_videoCommon.OriginalFilename));
+        Assert.That(fileResult.EnableRangeProcessing, Is.True);
+    }
+
+    [TestCase(null)]
+    [TestCase("expired-token")]
+    [TestCase("wrong-video-token")]
+    [TestCase("wrong-purpose-token")]
+    public async Task GetVideoFile_InvalidPlaybackTokenWithoutBearer_Returns401(string? playbackToken)
+    {
+        if (playbackToken != null)
+        {
+            _mockVideoPlaybackTokenService
+                .Setup(s => s.Validate(playbackToken, _videoCommon.Id))
+                .Returns((int?)null);
+        }
+        SetCurrentUser(null);
+
+        var result = await _controller.GetVideoFile(_videoCommon.Id, playbackToken, CancellationToken.None);
+
+        Assert.That(result, Is.TypeOf<ObjectResult>());
+        Assert.That(((ObjectResult)result).StatusCode, Is.EqualTo(StatusCodes.Status401Unauthorized));
+        _mockVideoStorageService.Verify(s => s.GetAbsolutePath(It.IsAny<string>()), Times.Never);
+    }
+
+    [TestCase("clip.mp4",  "video/mp4")]
+    [TestCase("clip.m4v",  "video/x-m4v")]
+    [TestCase("clip.webm", "video/webm")]
+    [TestCase("clip.ogv",  "video/ogg")]
+    [TestCase("clip.ogg",  "video/ogg")]
+    [TestCase("clip.mov",  "video/quicktime")]
+    [TestCase("clip.avi",  "video/x-msvideo")]
+    [TestCase("clip.mkv",  "video/x-matroska")]
+    [TestCase("clip.bin",  "application/octet-stream")]
+    public async Task GetVideoFile_ReturnsCorrectContentTypeForExtension(string originalFilename, string expectedContentType)
+    {
+        var video = new Video
+        {
+            Id = 100,
+            Title = "Mime Test",
+            Filename = $"0001/{originalFilename}",
+            OriginalFilename = originalFilename,
+            FileSizeBytes = 1024,
+            AccountId = _account1.Id,
+            Account = _account1
+        };
+        _dbContext.Videos.Add(video);
+        _dbContext.SaveChanges();
+
+        _mockVideoStorageService.Setup(s => s.GetAbsolutePath(video.Filename)).Returns($"/storage/{video.Filename}");
+        SetCurrentUser(_admin.Id);
+
+        var result = await _controller.GetVideoFile(video.Id, ct: CancellationToken.None);
+
+        Assert.That(result, Is.TypeOf<PhysicalFileResult>());
+        Assert.That(((PhysicalFileResult)result).ContentType, Is.EqualTo(expectedContentType));
+    }
+
+    [Test]
+    public async Task GetVideoFile_ValidId_ReturnsCorrectPhysicalPathDownloadNameAndRangeSupport()
+    {
+        var expectedPath = "/storage/0001/video1.mp4";
+        _mockVideoStorageService.Setup(s => s.GetAbsolutePath(_videoAccount1.Filename)).Returns(expectedPath);
+        SetCurrentUser(_admin.Id);
+
+        var result = await _controller.GetVideoFile(_videoAccount1.Id, ct: CancellationToken.None);
+
+        Assert.That(result, Is.TypeOf<PhysicalFileResult>());
+        var fileResult = (PhysicalFileResult)result;
+        Assert.That(fileResult.FileName, Is.EqualTo(expectedPath));
+        Assert.That(fileResult.FileDownloadName, Is.Null.Or.Empty);
+        Assert.That(_controller.Response.Headers["Content-Disposition"].ToString(), Does.Contain("inline"));
+        Assert.That(_controller.Response.Headers["Content-Disposition"].ToString(), Does.Contain(_videoAccount1.OriginalFilename));
+        Assert.That(fileResult.ContentType, Is.EqualTo("video/mp4"));
+        Assert.That(fileResult.EnableRangeProcessing, Is.True);
     }
 
     [Test]

--- a/MediaPi.Core.Tests/Controllers/VideosControllerTests.cs
+++ b/MediaPi.Core.Tests/Controllers/VideosControllerTests.cs
@@ -184,6 +184,28 @@ public class VideosControllerTests
     }
 
     [Test]
+    public async Task GetVideos_Engineer_Returns403()
+    {
+        var engineerRole = new Role { RoleId = UserRoleConstants.InstallationEngineer, Name = "Engineer" };
+        _dbContext.Roles.Add(engineerRole);
+        var engineer = new User
+        {
+            Id = 10,
+            Email = "engineer@example.com",
+            Password = "hash",
+            UserRoles = [new UserRole { UserId = 10, RoleId = engineerRole.Id, Role = engineerRole }]
+        };
+        _dbContext.Users.Add(engineer);
+        _dbContext.SaveChanges();
+        SetCurrentUser(engineer.Id);
+
+        var result = await _controller.GetVideos();
+
+        Assert.That(result.Result, Is.TypeOf<ObjectResult>());
+        Assert.That(((ObjectResult)result.Result!).StatusCode, Is.EqualTo(StatusCodes.Status403Forbidden));
+    }
+
+    [Test]
     public async Task GetVideo_ManagerOtherAccount_Returns403()
     {
         SetCurrentUser(_managerAccount1.Id);
@@ -813,6 +835,71 @@ public class VideosControllerTests
         Assert.That(_dbContext.Videos.Count(), Is.EqualTo(3));
         _mockVideoStorageService.Verify(s => s.DeleteVideoAsync("0002/first.mp4", It.IsAny<CancellationToken>()), Times.Once);
         _mockVideoStorageService.Verify(s => s.DeleteVideoAsync("0001/video1.mp4", It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Test]
+    public void UploadVideos_SaveThrows_RethrowsAfterCleanup()
+    {
+        SetCurrentUser(_admin.Id);
+        var file1 = CreateFormFile("one.mp4", "one");
+        var file2 = CreateFormFile("two.mp4", "two");
+        var file1SaveResult = new VideoSaveResult
+        {
+            Filename = "0099/one.mp4",
+            OriginalFilename = "one.mp4",
+            FileSizeBytes = (uint)file1.Length,
+            DurationSeconds = 60
+        };
+        _mockVideoStorageService
+            .SetupSequence(s => s.SaveVideoAsync(It.IsAny<IFormFile>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(file1SaveResult)
+            .ThrowsAsync(new InvalidOperationException("Storage failure"));
+        _mockVideoStorageService
+            .Setup(s => s.DeleteVideoAsync("0099/one.mp4", It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        var item = new VideoBatchUploadItem
+        {
+            AccountId = _account1.Id,
+            Files = [file1, file2],
+            Titles = ["First Video", "Second Video"]
+        };
+
+        Assert.ThrowsAsync<InvalidOperationException>(() => _controller.UploadVideos(item, CancellationToken.None));
+        _mockVideoStorageService.Verify(s => s.DeleteVideoAsync("0099/one.mp4", It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Test]
+    public void UploadVideos_SaveThrows_CleanupDeleteFails_LogsWarningAndRethrows()
+    {
+        SetCurrentUser(_admin.Id);
+        var file1 = CreateFormFile("one.mp4", "one");
+        var file2 = CreateFormFile("two.mp4", "two");
+        var file1SaveResult = new VideoSaveResult
+        {
+            Filename = "0099/one.mp4",
+            OriginalFilename = "one.mp4",
+            FileSizeBytes = (uint)file1.Length,
+            DurationSeconds = 60
+        };
+        _mockVideoStorageService
+            .SetupSequence(s => s.SaveVideoAsync(It.IsAny<IFormFile>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(file1SaveResult)
+            .ThrowsAsync(new InvalidOperationException("Storage failure"));
+        _mockVideoStorageService
+            .Setup(s => s.DeleteVideoAsync("0099/one.mp4", It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new IOException("Delete failed"));
+
+        var item = new VideoBatchUploadItem
+        {
+            AccountId = _account1.Id,
+            Files = [file1, file2],
+            Titles = ["First Video", "Second Video"]
+        };
+
+        // The original save exception is rethrown; the delete failure is swallowed
+        Assert.ThrowsAsync<InvalidOperationException>(() => _controller.UploadVideos(item, CancellationToken.None));
+        _mockVideoStorageService.Verify(s => s.DeleteVideoAsync("0099/one.mp4", It.IsAny<CancellationToken>()), Times.Once);
     }
 
     [Test]

--- a/MediaPi.Core.Tests/Controllers/VideosControllerTests.cs
+++ b/MediaPi.Core.Tests/Controllers/VideosControllerTests.cs
@@ -186,7 +186,7 @@ public class VideosControllerTests
     [Test]
     public async Task GetVideos_Engineer_Returns403()
     {
-        var engineerRole = new Role { RoleId = UserRoleConstants.InstallationEngineer, Name = "Engineer" };
+        var engineerRole = new Role { RoleId = UserRoleConstants.InstallationEngineer, Name = "Installation Engineer" };
         _dbContext.Roles.Add(engineerRole);
         var engineer = new User
         {

--- a/MediaPi.Core/Authorization/VideoPlaybackTokenService.cs
+++ b/MediaPi.Core/Authorization/VideoPlaybackTokenService.cs
@@ -1,0 +1,120 @@
+// Copyright (C) 2026 sw.consulting
+// This file is a part of Media Pi backend
+
+using MediaPi.Core.Settings;
+using Microsoft.Extensions.Options;
+using Microsoft.IdentityModel.Tokens;
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+using System.Security.Cryptography;
+using System.Text;
+
+namespace MediaPi.Core.Authorization;
+
+public sealed record VideoPlaybackToken(string Token, DateTime ExpiresAt);
+
+public interface IVideoPlaybackTokenService
+{
+    VideoPlaybackToken Generate(int userId, int videoId);
+    int? Validate(string? token, int videoId);
+}
+
+public class VideoPlaybackTokenService : IVideoPlaybackTokenService
+{
+    private const string IdClaim = "id";
+    private const string VideoIdClaim = "videoId";
+    private const string PurposeClaim = "purpose";
+    private const string PlaybackPurpose = "video-playback";
+    private static readonly TimeSpan TokenLifetime = TimeSpan.FromMinutes(60);
+
+    private readonly AppSettings _appSettings;
+    private readonly ILogger<VideoPlaybackTokenService> _logger;
+
+    public VideoPlaybackTokenService(IOptions<AppSettings> appSettings, ILogger<VideoPlaybackTokenService> logger)
+    {
+        _appSettings = appSettings.Value;
+        _logger = logger;
+
+        if (string.IsNullOrEmpty(_appSettings.Secret))
+        {
+            _logger.LogError("JWT secret not configured");
+            throw new Exception("JWT secret not configured");
+        }
+    }
+
+    public VideoPlaybackToken Generate(int userId, int videoId)
+    {
+        var expiresAt = DateTime.UtcNow.Add(TokenLifetime);
+        var tokenHandler = new JwtSecurityTokenHandler();
+        var key = CreateSigningKey();
+        var tokenDescriptor = new SecurityTokenDescriptor
+        {
+            Subject = new ClaimsIdentity(new[]
+            {
+                new Claim(IdClaim, userId.ToString()),
+                new Claim(VideoIdClaim, videoId.ToString()),
+                new Claim(PurposeClaim, PlaybackPurpose)
+            }),
+            Expires = expiresAt,
+            SigningCredentials = new SigningCredentials(key, SecurityAlgorithms.HmacSha256Signature)
+        };
+
+        var token = tokenHandler.CreateToken(tokenDescriptor);
+        return new VideoPlaybackToken(tokenHandler.WriteToken(token), expiresAt);
+    }
+
+    public int? Validate(string? token, int videoId)
+    {
+        if (string.IsNullOrWhiteSpace(token)) return null;
+
+        var tokenHandler = new JwtSecurityTokenHandler();
+        try
+        {
+            tokenHandler.ValidateToken(token, new TokenValidationParameters
+            {
+                ValidateIssuerSigningKey = true,
+                IssuerSigningKey = CreateSigningKey(),
+                ValidateIssuer = false,
+                ValidateAudience = false,
+                ValidateLifetime = true,
+                ClockSkew = TimeSpan.Zero
+            }, out var validatedToken);
+
+            if (validatedToken is not JwtSecurityToken jwtToken) return null;
+
+            var purpose = jwtToken.Claims.FirstOrDefault(x => x.Type == PurposeClaim)?.Value;
+            if (!string.Equals(purpose, PlaybackPurpose, StringComparison.Ordinal)) return null;
+
+            if (!int.TryParse(jwtToken.Claims.FirstOrDefault(x => x.Type == VideoIdClaim)?.Value, out var tokenVideoId)
+                || tokenVideoId != videoId)
+            {
+                return null;
+            }
+
+            if (!int.TryParse(jwtToken.Claims.FirstOrDefault(x => x.Type == IdClaim)?.Value, out var userId)) return null;
+
+            return userId;
+        }
+        catch (SecurityTokenExpiredException ex)
+        {
+            _logger.LogWarning(ex, "Video playback token expired");
+            return null;
+        }
+        catch (SecurityTokenException ex)
+        {
+            _logger.LogWarning(ex, "Invalid video playback token");
+            return null;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error validating video playback token");
+            return null;
+        }
+    }
+
+    private SymmetricSecurityKey CreateSigningKey()
+    {
+        var key = SHA256.HashData(Encoding.UTF8.GetBytes(_appSettings.Secret!));
+        return new SymmetricSecurityKey(key);
+    }
+}

--- a/MediaPi.Core/Authorization/VideoPlaybackTokenService.cs
+++ b/MediaPi.Core/Authorization/VideoPlaybackTokenService.cs
@@ -38,7 +38,7 @@ public class VideoPlaybackTokenService : IVideoPlaybackTokenService
         if (string.IsNullOrEmpty(_appSettings.Secret))
         {
             _logger.LogError("JWT secret not configured");
-            throw new Exception("JWT secret not configured");
+            throw new InvalidOperationException("JWT secret not configured");
         }
     }
 

--- a/MediaPi.Core/Authorization/VideoPlaybackTokenService.cs
+++ b/MediaPi.Core/Authorization/VideoPlaybackTokenService.cs
@@ -114,7 +114,7 @@ public class VideoPlaybackTokenService : IVideoPlaybackTokenService
 
     private SymmetricSecurityKey CreateSigningKey()
     {
-        var key = SHA256.HashData(Encoding.UTF8.GetBytes(_appSettings.Secret!));
+        var key = SHA256.HashData(Encoding.UTF8.GetBytes(_appSettings.Secret! + ":video-playback"));
         return new SymmetricSecurityKey(key);
     }
 }

--- a/MediaPi.Core/Controllers/VideosController.cs
+++ b/MediaPi.Core/Controllers/VideosController.cs
@@ -657,7 +657,7 @@ public class VideosController(
             if (userId.HasValue) return await LoadUser(userId.Value, ct);
         }
 
-        return await CurrentUser();
+return _curUserId == 0 ? null : await CurrentUser();
     }
 
     private async Task<User?> LoadUser(int userId, CancellationToken ct)

--- a/MediaPi.Core/Controllers/VideosController.cs
+++ b/MediaPi.Core/Controllers/VideosController.cs
@@ -654,7 +654,7 @@ public class VideosController(
         if (!string.IsNullOrWhiteSpace(playbackToken))
         {
             var userId = _videoPlaybackTokenService.Validate(playbackToken, videoId);
-            return userId.HasValue ? await LoadUser(userId.Value, ct) : null;
+            if (userId.HasValue) return await LoadUser(userId.Value, ct);
         }
 
         return await CurrentUser();

--- a/MediaPi.Core/Controllers/VideosController.cs
+++ b/MediaPi.Core/Controllers/VideosController.cs
@@ -13,6 +13,7 @@ using MediaPi.Core.Services.Interfaces;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Net.Http.Headers;
 
 namespace MediaPi.Core.Controllers;
 
@@ -26,12 +27,14 @@ public class VideosController(
     IUserInformationService userInformationService,
     IVideoStorageService videoStorageService,
     IPlaylistAccessService playlistAccessService,
+    IVideoPlaybackTokenService videoPlaybackTokenService,
     AppDbContext db,
     ILogger<VideosController> logger) : MediaPiControllerBase(httpContextAccessor, db, logger)
 {
     private readonly IUserInformationService _userInformationService = userInformationService;
     private readonly IVideoStorageService _videoStorageService = videoStorageService;
     private readonly IPlaylistAccessService _playlistAccessService = playlistAccessService;
+    private readonly IVideoPlaybackTokenService _videoPlaybackTokenService = videoPlaybackTokenService;
 
     [HttpGet]
     [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(IEnumerable<VideoViewItem>))]
@@ -129,6 +132,57 @@ public class VideosController(
         if (!_userInformationService.UserCanViewVideo(user, video.AccountId)) return _403();
 
         return video.ToViewItem();
+    }
+
+    [HttpPost("{id:int}/playback-token")]
+    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(VideoPlaybackTokenViewItem))]
+    [ProducesResponseType(StatusCodes.Status403Forbidden, Type = typeof(ErrMessage))]
+    [ProducesResponseType(StatusCodes.Status404NotFound, Type = typeof(ErrMessage))]
+    public async Task<ActionResult<VideoPlaybackTokenViewItem>> CreatePlaybackToken(int id, CancellationToken ct = default)
+    {
+        var user = await CurrentUser();
+        if (user == null) return _403();
+
+        var video = await _db.Videos.AsNoTracking().FirstOrDefaultAsync(v => v.Id == id, ct);
+        if (video == null) return _404Video(id);
+
+        if (!_userInformationService.UserCanViewVideo(user, video.AccountId)) return _403();
+
+        var token = _videoPlaybackTokenService.Generate(user.Id, video.Id);
+        return Ok(new VideoPlaybackTokenViewItem
+        {
+            Token = token.Token,
+            ExpiresAt = token.ExpiresAt,
+            Url = BuildPlaybackUrl(video.Id, token.Token)
+        });
+    }
+
+    [AllowAnonymous]
+    [HttpGet("{id:int}/file")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized, Type = typeof(ErrMessage))]
+    [ProducesResponseType(StatusCodes.Status403Forbidden, Type = typeof(ErrMessage))]
+    [ProducesResponseType(StatusCodes.Status404NotFound, Type = typeof(ErrMessage))]
+    public async Task<IActionResult> GetVideoFile(int id, [FromQuery] string? playbackToken = null, CancellationToken ct = default)
+    {
+        var user = await ResolvePlaybackUser(id, playbackToken, ct);
+        if (user == null) return _401PlaybackToken();
+
+        var video = await _db.Videos.AsNoTracking().FirstOrDefaultAsync(v => v.Id == id, ct);
+        if (video == null) return _404Video(id);
+
+        if (!_userInformationService.UserCanViewVideo(user, video.AccountId)) return _403();
+
+        var path = _videoStorageService.GetAbsolutePath(video.Filename);
+        var contentType = ResolveVideoContentType(video.OriginalFilename);
+        Response.Headers[HeaderNames.ContentDisposition] = new ContentDispositionHeaderValue("inline")
+        {
+            FileNameStar = video.OriginalFilename
+        }.ToString();
+        return new PhysicalFileResult(path, contentType)
+        {
+            EnableRangeProcessing = true
+        };
     }
 
     [HttpPost("upload")]
@@ -572,6 +626,47 @@ public class VideosController(
     private static int? NormalizeAccountId(int accountId) => accountId == 0 ? null : accountId;
     private static int? NormalizeCategoryId(int categoryId) => categoryId == 0 ? null : categoryId;
     private static int? ResolveCategoryId(int? categoryId) => categoryId.HasValue ? NormalizeCategoryId(categoryId.Value) : null;
+
+    private static string ResolveVideoContentType(string filename) =>
+        Path.GetExtension(filename).ToLowerInvariant() switch
+        {
+            ".mp4"  => "video/mp4",
+            ".m4v"  => "video/x-m4v",
+            ".webm" => "video/webm",
+            ".ogv" or ".ogg" => "video/ogg",
+            ".mov"  => "video/quicktime",
+            ".avi"  => "video/x-msvideo",
+            ".mkv"  => "video/x-matroska",
+            _       => "application/octet-stream"
+        };
+
+    private static string BuildPlaybackUrl(int videoId, string token) =>
+        $"/api/videos/{videoId}/file?playbackToken={Uri.EscapeDataString(token)}";
+
+    private ObjectResult _401PlaybackToken()
+    {
+        return StatusCode(StatusCodes.Status401Unauthorized,
+                          new ErrMessage { Msg = "Недействительная или просроченная ссылка на видеофайл" });
+    }
+
+    private async Task<User?> ResolvePlaybackUser(int videoId, string? playbackToken, CancellationToken ct)
+    {
+        if (!string.IsNullOrWhiteSpace(playbackToken))
+        {
+            var userId = _videoPlaybackTokenService.Validate(playbackToken, videoId);
+            return userId.HasValue ? await LoadUser(userId.Value, ct) : null;
+        }
+
+        return await CurrentUser();
+    }
+
+    private async Task<User?> LoadUser(int userId, CancellationToken ct)
+    {
+        return await _db.Users
+            .Include(u => u.UserRoles).ThenInclude(ur => ur.Role)
+            .Include(u => u.UserAccounts)
+            .FirstOrDefaultAsync(u => u.Id == userId, ct);
+    }
 
     private async Task<ObjectResult?> ValidateCategory(int? categoryId, CancellationToken ct)
     {

--- a/MediaPi.Core/Program.cs
+++ b/MediaPi.Core/Program.cs
@@ -49,6 +49,7 @@ builder.Services
     .Configure<SubscriptionSettings>(config.GetSection("SubscriptionSettings"))
     .Configure<DeviceMonitorSettings>(config.GetSection("DeviceMonitoringSettings"))
     .AddScoped<IJwtUtils, JwtUtils>()
+    .AddScoped<IVideoPlaybackTokenService, VideoPlaybackTokenService>()
     .AddScoped<IUserInformationService, UserInformationService>()
     .AddSingleton<ISubscriptionTimeService, SubscriptionTimeService>()
     .AddScoped<IPlaylistAccessService, PlaylistAccessService>()

--- a/MediaPi.Core/RestModels/VideoPlaybackTokenViewItem.cs
+++ b/MediaPi.Core/RestModels/VideoPlaybackTokenViewItem.cs
@@ -1,0 +1,11 @@
+// Copyright (C) 2026 sw.consulting
+// This file is a part of Media Pi backend
+
+namespace MediaPi.Core.RestModels;
+
+public class VideoPlaybackTokenViewItem
+{
+    public required string Token { get; init; }
+    public required DateTime ExpiresAt { get; init; }
+    public required string Url { get; init; }
+}


### PR DESCRIPTION
Introduces a token-based mechanism for secure video playback.

## Changes Made

### New Endpoints
- **`POST /api/videos/{id}/playback-token`** — generates a short-lived JWT playback token and a pre-signed URL for the video file.
- **`GET /api/videos/{id}/file`** — anonymous endpoint that serves video files; accepts either a valid playback token (query string) or a Bearer-authenticated session. Supports `Content-Disposition: inline` and HTTP range requests for streaming.

### Security
- Playback tokens are signed with a key derived from `secret + ":video-playback"`, ensuring they cannot be replayed as ****** tokens against other protected endpoints.
- `ResolvePlaybackUser` falls through to the Bearer-authenticated session when a supplied `playbackToken` query param is invalid or stale, preventing authenticated callers from being blocked by an expired token.
- `VideoPlaybackTokenService` constructor throws `InvalidOperationException` when the JWT secret is not configured.

### Test Coverage
- Unit tests for `VideoPlaybackTokenService`: constructor guard (null/empty secret), token generation and validation, wrong-video, wrong-purpose, expired, and wrong-signing-key scenarios.
- Controller tests for both new endpoints covering success paths, 401/403/404 responses, MIME type resolution, range-processing, and error-handling branches (`UploadVideos` catch-and-rethrow, `CleanupSavedVideos` exception swallowing).
- Aggregate line coverage for modified code: **99%** (`VideoPlaybackTokenService` 94%, `VideosController` 99.7%).